### PR TITLE
Inspect 'X-Forwarded-Proto' header for HTTPS

### DIFF
--- a/source/Core/Configuration/AppBuilderExtensions/ConfigureIdentityServerBaseUrlExtension.cs
+++ b/source/Core/Configuration/AppBuilderExtensions/ConfigureIdentityServerBaseUrlExtension.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System;
 using IdentityServer3.Core.Extensions;
 
 namespace Owin
@@ -34,7 +35,7 @@ namespace Owin
                 var origin = publicOrigin;
                 if (origin.IsMissing())
                 {
-                    origin = request.Uri.Scheme + "://" + request.Host.Value;
+                    origin = Uri.UriSchemeHttps + "://" + request.Host.Value;
                 }
 
                 ctx.Environment.SetIdentityServerHost(origin);

--- a/source/Core/Configuration/Hosting/RequireSslMiddleware.cs
+++ b/source/Core/Configuration/Hosting/RequireSslMiddleware.cs
@@ -35,7 +35,11 @@ namespace IdentityServer3.Core.Configuration.Hosting
         {
             var context = new OwinContext(env);
 
-            if (context.Request.Uri.Scheme != Uri.UriSchemeHttps)
+            var isSecureConnection = context.Request.IsSecure ||
+                String.Equals(context.Request.Headers["X-Forwarded-Proto"], Uri.UriSchemeHttps,
+                StringComparison.InvariantCultureIgnoreCase);
+
+            if (!isSecureConnection)
             {
                 context.Response.StatusCode = 403;
                 context.Response.ReasonPhrase = Messages.SslRequired;


### PR DESCRIPTION
I tried deploying the IdentityServer sample on [AppHarbor](https://appharbor.com/) and I got "SSL is required" error even when the page was accessed through a valid `https` connection. Rune @runesoerensen from @AppHarbor gave the following hint about the error: 

> The code that produces this messages probably doesn't inspect the `X-Forwarded-Proto` headers to see if the client connected using SSL. AppHarbor terminates SSL at the load balancer level, so to your application it'll appear like the client connected using HTTP, when it is in fact just the connection between the load balancer and the worker that happen over HTTP.

> You might want to take a look at [this `RequireHttpsAttribute` implementation](https://gist.github.com/runesoerensen/915869), which is compatible with a load balanced setup like AppHarbor's as it also inspects the host header.

So I modified `RequireSslMiddleware` in IdentityServer to make that additional check and it seems to be working now. I don't know if this produces any security vulnerabilities but added this here anyways for your consideration as this may be the case with other load-balanced setups too.

Thanks!