### PR TITLE
Resource Owner flow: Allow ErrorDescription to be passed back to client

### DIFF
--- a/source/Core/Endpoints/Connect/TokenEndpointController.cs
+++ b/source/Core/Endpoints/Connect/TokenEndpointController.cs
@@ -120,7 +120,7 @@ namespace Thinktecture.IdentityServer.Core.Endpoints
 
             if (result.IsError)
             {
-                return this.TokenErrorResponse(result.Error);
+                return this.TokenErrorResponse(result.Error, result.ErrorDescription);
             }
 
             // return response

--- a/source/Core/Extensions/ResultExtensions.cs
+++ b/source/Core/Extensions/ResultExtensions.cs
@@ -31,5 +31,10 @@ namespace Thinktecture.IdentityServer.Core.Extensions
         {
             return new TokenErrorResult(error);
         }
+
+        public static IHttpActionResult TokenErrorResponse(this ApiController controller, string error, string errorDescription)
+        {
+            return new TokenErrorResult(error, errorDescription);
+        }
     }
 }

--- a/source/Core/Results/TokenErrorResult.cs
+++ b/source/Core/Results/TokenErrorResult.cs
@@ -29,10 +29,17 @@ namespace Thinktecture.IdentityServer.Core.Results
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
         
         public string Error { get; internal set; }
+        public string ErrorDescription { get; internal set; }
 
         public TokenErrorResult(string error)
         {
             Error = error;
+        }
+
+        public TokenErrorResult(string error, string errorDescription)
+        {
+            Error = error;
+            ErrorDescription = errorDescription;
         }
 
         public Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
@@ -44,7 +51,8 @@ namespace Thinktecture.IdentityServer.Core.Results
         {
             var dto = new ErrorDto
             {
-                error = Error 
+                error = Error,
+                error_description = ErrorDescription,
             };
 
             var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
@@ -59,6 +67,7 @@ namespace Thinktecture.IdentityServer.Core.Results
         internal class ErrorDto
         {
             public string error { get; set; }
+            public string error_description { get; set; }
         }    
     }
 }

--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -423,6 +423,11 @@ namespace Thinktecture.IdentityServer.Core.Validation
                 LogError("User authentication failed");
                 RaiseFailedResourceOwnerAuthenticationEvent(userName, signInMessage);
 
+                if (authnResult != null)
+                {
+                    return Invalid(Constants.TokenErrors.InvalidGrant, authnResult.ErrorMessage);
+                }
+
                 return Invalid(Constants.TokenErrors.InvalidGrant);
             }
 
@@ -628,6 +633,17 @@ namespace Thinktecture.IdentityServer.Core.Validation
                 IsError = true,
                 ErrorType = ErrorTypes.Client,
                 Error = error
+            };
+        }
+
+        private ValidationResult Invalid(string error, string errorDescription)
+        {
+            return new ValidationResult
+            {
+                IsError = true,
+                ErrorType = ErrorTypes.Client,
+                Error = error,
+                ErrorDescription = errorDescription
             };
         }
 

--- a/source/Core/Validation/ValidationResult.cs
+++ b/source/Core/Validation/ValidationResult.cs
@@ -42,6 +42,13 @@ namespace Thinktecture.IdentityServer.Core.Validation
         /// The type of the error.
         /// </value>
         public ErrorTypes ErrorType { get; set; }
+        /// <summary>
+        /// Gets or sets the description of the error.
+        /// </summary>
+        /// <value>
+        /// The description of the error.
+        /// </value>
+        public string ErrorDescription { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ValidationResult"/> class.

--- a/source/Tests/UnitTests/Validation/Setup/TestUserService.cs
+++ b/source/Tests/UnitTests/Validation/Setup/TestUserService.cs
@@ -34,7 +34,7 @@ namespace Thinktecture.IdentityServer.Tests.Validation
                 return Task.FromResult(new AuthenticateResult(p));
             }
 
-            return Task.FromResult<AuthenticateResult>(null);
+            return Task.FromResult<AuthenticateResult>(new AuthenticateResult("Username and/or password incorrect"));
         }
 
         public Task<IEnumerable<Claim>> GetProfileDataAsync(ClaimsPrincipal sub, IEnumerable<string> requestedClaimTypes = null)

--- a/source/Tests/UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
+++ b/source/Tests/UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
@@ -211,6 +211,7 @@ namespace Thinktecture.IdentityServer.Tests.Validation.TokenRequest
 
             result.IsError.Should().BeTrue();
             result.Error.Should().Be(Constants.TokenErrors.InvalidGrant);
+            result.ErrorDescription.Should().Be("Username and/or password incorrect");
         }
     }
 }


### PR DESCRIPTION
Currently, the Resource Owner flow doesn't pass back any error messages
from the UserService. The RFC in section 5.2 specifies an optional
error_description field.

This change is to pass this back to the client.