### PR TITLE
Pass ErrorDescription back in client response for Resource Owner flow

### DIFF
--- a/source/Core/Endpoints/Connect/TokenEndpointController.cs
+++ b/source/Core/Endpoints/Connect/TokenEndpointController.cs
@@ -116,7 +116,7 @@ namespace IdentityServer3.Core.Endpoints
 
             if (requestResult.IsError)
             {
-                return this.TokenErrorResponse(requestResult.Error);
+                return this.TokenErrorResponse(requestResult.Error, requestResult.ErrorDescription);
             }
 
             // return response

--- a/source/Core/Extensions/ResultExtensions.cs
+++ b/source/Core/Extensions/ResultExtensions.cs
@@ -31,5 +31,10 @@ namespace IdentityServer3.Core.Extensions
         {
             return new TokenErrorResult(error);
         }
+
+        public static IHttpActionResult TokenErrorResponse(this ApiController controller, string error, string errorDescription)
+        {
+            return new TokenErrorResult(error, errorDescription);
+        }
     }
 }

--- a/source/Core/Results/TokenErrorResult.cs
+++ b/source/Core/Results/TokenErrorResult.cs
@@ -21,6 +21,7 @@ using System.Net.Http.Formatting;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Newtonsoft.Json;
 
 namespace IdentityServer3.Core.Results
 {
@@ -29,11 +30,19 @@ namespace IdentityServer3.Core.Results
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
         
         public string Error { get; internal set; }
+        public string ErrorDescription { get; internal set; }
 
         public TokenErrorResult(string error)
         {
             Error = error;
         }
+
+        public TokenErrorResult(string error, string errorDescription)
+        {
+            Error = error;
+            ErrorDescription = errorDescription;
+        }
+
 
         public Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
         {
@@ -44,7 +53,8 @@ namespace IdentityServer3.Core.Results
         {
             var dto = new ErrorDto
             {
-                error = Error 
+                error = Error,
+                error_description = ErrorDescription
             };
 
             var response = new HttpResponseMessage(HttpStatusCode.BadRequest)
@@ -59,6 +69,8 @@ namespace IdentityServer3.Core.Results
         internal class ErrorDto
         {
             public string error { get; set; }
+            [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+            public string error_description { get; set; }
         }    
     }
 }

--- a/source/Core/Results/TokenErrorResult.cs
+++ b/source/Core/Results/TokenErrorResult.cs
@@ -43,7 +43,6 @@ namespace IdentityServer3.Core.Results
             ErrorDescription = errorDescription;
         }
 
-
         public Task<HttpResponseMessage> ExecuteAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(Execute());

--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -423,6 +423,11 @@ namespace IdentityServer3.Core.Validation
                 LogError("User authentication failed");
                 await RaiseFailedResourceOwnerAuthenticationEventAsync(userName, signInMessage);
 
+                if (authnResult != null)
+                {
+                    return Invalid(Constants.TokenErrors.InvalidGrant, authnResult.ErrorMessage);
+                }
+
                 return Invalid(Constants.TokenErrors.InvalidGrant);
             }
 
@@ -627,6 +632,16 @@ namespace IdentityServer3.Core.Validation
             {
                 IsError = true,
                 Error = error
+            };
+        }
+
+        private TokenRequestValidationResult Invalid(string error, string errorDescription)
+        {
+            return new TokenRequestValidationResult
+            {
+                IsError = true,
+                Error = error,
+                ErrorDescription = errorDescription
             };
         }
 

--- a/source/Core/Validation/ValidationResult.cs
+++ b/source/Core/Validation/ValidationResult.cs
@@ -44,5 +44,13 @@ namespace IdentityServer3.Core.Validation
         /// The error.
         /// </value>
         public string Error { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error description.
+        /// </summary>
+        /// <value>
+        /// The error description.
+        /// </value>
+        public string ErrorDescription { get; set; }
     }
 }

--- a/source/Tests/UnitTests/Validation/Setup/TestUserService.cs
+++ b/source/Tests/UnitTests/Validation/Setup/TestUserService.cs
@@ -34,7 +34,7 @@ namespace IdentityServer3.Tests.Validation
                 return Task.FromResult(new AuthenticateResult(p));
             }
 
-            return Task.FromResult<AuthenticateResult>(null);
+            return Task.FromResult<AuthenticateResult>(new AuthenticateResult("Username and/or password incorrect"));
         }
 
         public Task<IEnumerable<Claim>> GetProfileDataAsync(ClaimsPrincipal sub, IEnumerable<string> requestedClaimTypes = null)

--- a/source/Tests/UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
+++ b/source/Tests/UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_ResourceOwner_Invalid.cs
@@ -211,6 +211,7 @@ namespace IdentityServer3.Tests.Validation.TokenRequest
 
             result.IsError.Should().BeTrue();
             result.Error.Should().Be(Constants.TokenErrors.InvalidGrant);
+            result.ErrorDescription.Should().Be("Username and/or password incorrect");
         }
     }
 }


### PR DESCRIPTION
Currently, the Resource Owner flow doesn't pass back any error messages
from the UserService. The RFC in section 5.2 specifies an optional
error_description field.

This change is to pass this back to the client.