### PR TITLE
Add LinkAccount acr value

### DIFF
--- a/source/Core/Constants.cs
+++ b/source/Core/Constants.cs
@@ -286,6 +286,7 @@ namespace IdentityServer3.Core
         {
             public const string HomeRealm = "idp:";
             public const string Tenant = "tenant:";
+            public const string LinkAccount = "linkaccount:";
         }
 
         public static class AuthorizeErrors

--- a/source/Core/Models/SignInMessage.cs
+++ b/source/Core/Models/SignInMessage.cs
@@ -60,6 +60,16 @@ namespace IdentityServer3.Core.Models
         public string Tenant { get; set; }
         
         /// <summary>
+        /// The local user account identifier. Can be used to link an external account
+        /// to a local user account. This is provided via the <c>"linkaccount:"</c>
+        /// prefix to the <c>acr</c> parameter on the authorize request.
+        /// </summary>
+        /// <value>
+        /// The local user account identifier.
+        /// </value>
+        public string LinkAccountId { get; set; }
+
+        /// <summary>
         /// The expected username the user will use to login. This is requested from the client 
         /// via the <c>login_hint</c> parameter on the authorize request.
         /// </summary>

--- a/source/Core/ResponseHandling/AuthorizeInteractionResponseGenerator.cs
+++ b/source/Core/ResponseHandling/AuthorizeInteractionResponseGenerator.cs
@@ -94,6 +94,14 @@ namespace IdentityServer3.Core.ResponseHandling
                 acrValues.Remove(tenant);
             }
 
+            // look for well-known acr value -- linkaccount
+            var linkAccountId = acrValues.FirstOrDefault(x => x.StartsWith(Constants.KnownAcrValues.LinkAccount));
+            if (linkAccountId.IsPresent())
+            {
+                _signIn.LinkAccountId = linkAccountId.Substring(Constants.KnownAcrValues.LinkAccount.Length);
+                acrValues.Remove(linkAccountId);
+            }
+
             // pass through any remaining acr values
             if (acrValues.Any())
             {

--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -405,6 +405,14 @@ namespace IdentityServer3.Core.Validation
                     acrValues.Remove(tenant);
                 }
 
+                // look for well-known acr value -- linkaccount
+                var linkAccountId = acrValues.FirstOrDefault(x => x.StartsWith(Constants.KnownAcrValues.LinkAccount));
+                if (linkAccountId.IsPresent())
+                {
+                    signInMessage.LinkAccountId = linkAccountId.Substring(Constants.KnownAcrValues.LinkAccount.Length);
+                    acrValues.Remove(linkAccountId);
+                }
+
                 // pass through any remaining acr values
                 if (acrValues.Any())
                 {

--- a/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
+++ b/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
@@ -117,6 +117,26 @@ namespace IdentityServer3.Tests.Endpoints
         }
 
         [Fact]
+        public void GetLogin_SignInMessageHasLinkAccountIdentifier()
+        {
+            var id = Guid.NewGuid().ToString();
+            var msg = new SignInMessage();
+            msg.IdP = "Google";
+            msg.ReturnUrl = Url("authorize");
+            msg.LinkAccountId = id;
+            var resp1 = GetLoginPage(msg);
+
+            var sub = new Claim(Constants.ClaimTypes.Subject, "123", ClaimValueTypes.String, "Google");
+            SignInIdentity = new ClaimsIdentity(new Claim[] { sub }, Constants.ExternalAuthenticationType);
+            var resp2 = client.GetAsync(resp1.Headers.Location.AbsoluteUri).Result;
+            client.SetCookies(resp2.GetCookies());
+
+            Get(Constants.RoutePaths.LoginExternalCallback);
+
+            mockUserService.Verify(x => x.AuthenticateExternalAsync(It.IsAny<ExternalIdentity>(), It.Is<SignInMessage>(y => y.LinkAccountId == id)));
+        }
+
+        [Fact]
         public void GetLogin_SignInMessageHasLoginHint_UsernameIsPopulatedFromLoginHint()
         {
             options.AuthenticationOptions.EnableLoginHint = true;


### PR DESCRIPTION
By passing the local user account identifier to this value, the authorize
endpoint can be used for linking an external account to the local account

Also see #1201