### PR TITLE
Cascade (optional) flag for the Revocation endpoint

### DIFF
--- a/source/Core/Validation/TokenRevocationRequestValidationResult.cs
+++ b/source/Core/Validation/TokenRevocationRequestValidationResult.cs
@@ -18,6 +18,7 @@ namespace IdentityServer3.Core.Validation
 {
     internal class TokenRevocationRequestValidationResult : ValidationResult
     {
+        public bool Cascade { get; set; }
         public string TokenTypeHint { get; set; }
         public string Token { get; set; }
     }

--- a/source/Core/Validation/TokenRevocationRequestValidator.cs
+++ b/source/Core/Validation/TokenRevocationRequestValidator.cs
@@ -68,11 +68,33 @@ namespace IdentityServer3.Core.Validation
                 if (Constants.SupportedTokenTypeHints.Contains(hint))
                 {
                     result.TokenTypeHint = hint;
+                    if (hint != Constants.TokenTypeHints.RefreshToken)
+                    {
+                        return Task.FromResult(result);
+                    }
                 }
                 else
                 {
                     result.IsError = true;
                     result.Error = Constants.RevocationErrors.UnsupportedTokenType;
+                }
+            }
+
+            ////////////////////////////
+            // check optional cascade flag
+            ///////////////////////////
+            var cascade = parameters.Get("cascade");
+            if (cascade.IsPresent())
+            {
+                bool value;
+                if (bool.TryParse(cascade, out value))
+                {
+                    result.Cascade = value;
+                }
+                else
+                {
+                    result.IsError = true;
+                    result.Error = Constants.TokenErrors.InvalidRequest;
                 }
             }
 

--- a/source/Core/Validation/TokenRevocationRequestValidator.cs
+++ b/source/Core/Validation/TokenRevocationRequestValidator.cs
@@ -68,10 +68,6 @@ namespace IdentityServer3.Core.Validation
                 if (Constants.SupportedTokenTypeHints.Contains(hint))
                 {
                     result.TokenTypeHint = hint;
-                    if (hint != Constants.TokenTypeHints.RefreshToken)
-                    {
-                        return Task.FromResult(result);
-                    }
                 }
                 else
                 {

--- a/source/Tests/UnitTests/Validation/RevocationRequestValidation.cs
+++ b/source/Tests/UnitTests/Validation/RevocationRequestValidation.cs
@@ -149,6 +149,7 @@ namespace IdentityServer3.Tests.Validation
 
             result.IsError.Should().BeFalse();
             result.Token.Should().Be("foo");
+            result.TokenTypeHint.Should().BeNull();
             result.Cascade.Should().Be(false);
         }
 

--- a/source/Tests/UnitTests/Validation/RevocationRequestValidation.cs
+++ b/source/Tests/UnitTests/Validation/RevocationRequestValidation.cs
@@ -27,7 +27,7 @@ namespace IdentityServer3.Tests.Validation
 {
     public class RevocationRequestValidation
     {
-        const string Category = "Revocation Request Validationn Tests";
+        const string Category = "Revocation Request Validation Tests";
 
         TokenRevocationRequestValidator _validator;
         IRefreshTokenStore _refreshTokens;
@@ -61,7 +61,7 @@ namespace IdentityServer3.Tests.Validation
         public async Task Missing_Token_Valid_Hint()
         {
             var client = await _clients.FindClientByIdAsync("codeclient");
-            
+
             var parameters = new NameValueCollection
             {
                 { "token_type_hint", "access_token" }
@@ -109,11 +109,34 @@ namespace IdentityServer3.Tests.Validation
             result.IsError.Should().BeFalse();
             result.Token.Should().Be("foo");
             result.TokenTypeHint.Should().Be("refresh_token");
+            result.Cascade.Should().Be(false);
         }
 
         [Fact]
         [Trait("Category", Category)]
-        public async Task Valid_Token_And_Missing_Hint()
+        public async Task Valid_Token_and_RefreshTokenHint_and_Cascade()
+        {
+            var client = await _clients.FindClientByIdAsync("codeclient");
+
+            var parameters = new NameValueCollection
+            {
+                { "token", "foo" },
+                { "token_type_hint", "refresh_token" },
+                { "cascade", "true" }
+            };
+
+            var result = await _validator.ValidateRequestAsync(parameters, client);
+
+            result.IsError.Should().BeFalse();
+            result.Token.Should().Be("foo");
+            result.TokenTypeHint.Should().Be("refresh_token");
+            result.Cascade.Should().Be(true);
+        }
+
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task Valid_Token_And_Missing_Hint_And_Missing_Cascade()
         {
             var client = await _clients.FindClientByIdAsync("codeclient");
 
@@ -126,7 +149,7 @@ namespace IdentityServer3.Tests.Validation
 
             result.IsError.Should().BeFalse();
             result.Token.Should().Be("foo");
-            result.TokenTypeHint.Should().BeNull();
+            result.Cascade.Should().Be(false);
         }
 
         [Fact]
@@ -145,6 +168,24 @@ namespace IdentityServer3.Tests.Validation
 
             result.IsError.Should().BeTrue();
             result.Error.Should().Be(Constants.RevocationErrors.UnsupportedTokenType);
+        }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task Valid_Token_And_Invalid_Cascade()
+        {
+            var client = await _clients.FindClientByIdAsync("codeclient");
+
+            var parameters = new NameValueCollection
+            {
+                { "token", "foo" },
+                { "cascade", "non_boolean_value" }
+            };
+
+            var result = await _validator.ValidateRequestAsync(parameters, client);
+
+            result.IsError.Should().BeTrue();
+            result.Error.Should().Be(Constants.TokenErrors.InvalidRequest);
         }
     }
 }


### PR DESCRIPTION
Adds an optional ```cascade``` boolean flag for the Revocation endpoint.  This flag determines whether or not to revoke a refresh token's associated access tokens. Refer to [RFC 7009 Section 2.1] (https://tools.ietf.org/html/rfc7009#section-2.1) and the open issue https://github.com/IdentityServer/IdentityServer3/issues/1111 in the 2.0 milestone.

If the ```cascade``` option is set to ```true``` and the token type is a refresh token, the controller logic executes the existing [RevokeAsync](https://github.com/IdentityServer/IdentityServer3/blob/2c0ef5f7dc3be0b804d1e1734dad634dc1288fad/source/Core/Services/ITransientDataRepository.cs#L65) logic.   Note that ```cascade``` option works with or without the presence of the ```token_type_hint```.   If the option is missing or set to ```false```, then only the refresh token itself will be revoked.   This option has no effect on requests for revoking an access (reference) token.

Unlike SalesForce, Google and reddit, I felt that making this optional would give flexibility to a client and/or API wanting to solely revoke an individual token versus cascading to related tokens.

Example: ```token=<<refresh token goes here>>&token_type_hint=refresh_token&cascade=true```

NOTE:  I didn't add support for an Access Token revocation that revokes its related Refresh Token, regardless of ```cascade``` option.   The spec said "MAY" for that scenario, unlike the "SHOULD" for refresh tokens revoking associated access tokens.   Anyone open to discussing/adding that functionality (which [Google OAuth2](https://developers.google.com/identity/protocols/OAuth2WebServer#tokenrevoke) supports)?  
