### PR TITLE
Found an incorrect filename for a recent commit

### DIFF
--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -220,7 +220,7 @@
     <Compile Include="Services\Default\AutofacDependencyResolver.cs" />
     <Compile Include="Services\Default\DefaultClientValidator.cs" />
     <Compile Include="Services\Default\DefaultCorsPolicyService.cs" />
-    <Compile Include="Services\Default\DefaultUserService.cs" />
+    <Compile Include="Services\Default\UserServiceBase.cs" />
     <Compile Include="Services\Default\PlainClientSecretValidator.cs" />
     <Compile Include="Services\Default\HashedClientSecretValidator.cs" />
     <Compile Include="Services\Default\EventServiceDecorator.cs" />


### PR DESCRIPTION
Unable to compile due to incorrect class name in the Core project file from commit:
https://github.com/IdentityServer/IdentityServer3/commit/df1d799d54288110dc0fa2ffbc60e649f993b397

Corrected the name from ```DefaultUserService``` to ```UserServiceBase```.