### PR TITLE
Refresh Token Revocation - automatic removal of related tokens

### DIFF
--- a/source/Core/Endpoints/Connect/RevocationEndpointController.cs
+++ b/source/Core/Endpoints/Connect/RevocationEndpointController.cs
@@ -160,7 +160,7 @@ namespace IdentityServer3.Core.Endpoints
             {
                 if (token.ClientId == client.ClientId)
                 {
-                    await _refreshTokens.RemoveAsync(handle);
+                    await _refreshTokens.RevokeAsync(token.SubjectId, token.ClientId);
                 }
                 else
                 {

--- a/source/Tests/UnitTests/Validation/RevocationRequestValidation.cs
+++ b/source/Tests/UnitTests/Validation/RevocationRequestValidation.cs
@@ -27,7 +27,7 @@ namespace IdentityServer3.Tests.Validation
 {
     public class RevocationRequestValidation
     {
-        const string Category = "Revocation Request Validationn Tests";
+        const string Category = "Revocation Request Validation Tests";
 
         TokenRevocationRequestValidator _validator;
         IRefreshTokenStore _refreshTokens;


### PR DESCRIPTION
Per [RFC 7009 Section 2.1](https://tools.ietf.org/html/rfc7009#section-2.1), automatically remove all access tokens related to a refresh token being revoked through the ```revocation``` endpoint.    Also corrected a typo in the ```Category``` value for the revocation validation test.

See discussion https://github.com/IdentityServer/IdentityServer3/issues/1111 in the 2.0 milestone and follow-up from original PR https://github.com/IdentityServer/IdentityServer3/pull/1394.