### PR TITLE
Fluent API for factory configuration

### DIFF
--- a/source/Core/Extensions/IdentityServerServiceFactoryExtensions.cs
+++ b/source/Core/Extensions/IdentityServerServiceFactoryExtensions.cs
@@ -18,6 +18,7 @@ using IdentityServer3.Core.Models;
 using IdentityServer3.Core.Services;
 using IdentityServer3.Core.Services.Caching;
 using IdentityServer3.Core.Services.Default;
+using IdentityServer3.Core.Services.InMemory;
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
@@ -211,6 +212,50 @@ namespace IdentityServer3.Core.Configuration
             if (factory.ViewService != null) throw new InvalidOperationException("A ViewService is already configured");
 
             factory.ViewService = new DefaultViewServiceRegistration(options);
+        }
+
+        /// <summary>
+        /// Configures the factory to use in-memory users.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="users">The users.</param>
+        /// <returns></returns>
+        public static IdentityServerServiceFactory UseInMemoryUsers(this IdentityServerServiceFactory factory, List<InMemoryUser> users)
+        {
+            factory.Register(new Registration<List<InMemoryUser>>(users));
+            factory.UserService = new Registration<IUserService, InMemoryUserService>();
+
+            return factory;
+        }
+
+        /// <summary>
+        /// Configures the factory to use in-memory clients.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="clients">The clients.</param>
+        /// <returns></returns>
+        public static IdentityServerServiceFactory UseInMemoryClients(this IdentityServerServiceFactory factory, IEnumerable<Client> clients)
+        {
+            factory.Register(new Registration<IEnumerable<Client>>(clients));
+            factory.ClientStore = new Registration<IClientStore>(typeof(InMemoryClientStore));
+
+            // todo: add in-mem CORS service
+
+            return factory;
+        }
+
+        /// <summary>
+        /// Configures the factory to use in-memory scopes.
+        /// </summary>
+        /// <param name="factory">The factory.</param>
+        /// <param name="scopes">The scopes.</param>
+        /// <returns></returns>
+        public static IdentityServerServiceFactory UseInMemoryScopes(this IdentityServerServiceFactory factory, IEnumerable<Scope> scopes)
+        {
+            factory.Register(new Registration<IEnumerable<Scope>>(scopes));
+            factory.ScopeStore = new Registration<IScopeStore>(typeof(InMemoryScopeStore));
+
+            return factory;
         }
     }
 }

--- a/source/Core/Extensions/IdentityServerServiceFactoryExtensions.cs
+++ b/source/Core/Extensions/IdentityServerServiceFactoryExtensions.cs
@@ -238,8 +238,7 @@ namespace IdentityServer3.Core.Configuration
         {
             factory.Register(new Registration<IEnumerable<Client>>(clients));
             factory.ClientStore = new Registration<IClientStore>(typeof(InMemoryClientStore));
-
-            // todo: add in-mem CORS service
+            factory.CorsPolicyService = new Registration<ICorsPolicyService>(new InMemoryCorsPolicyService(clients));
 
             return factory;
         }

--- a/source/Host/Startup.cs
+++ b/source/Host/Startup.cs
@@ -49,10 +49,10 @@ namespace IdentityServer3.Host
 
             app.Map("/core", coreApp =>
                 {
-                    var factory = InMemoryFactory.Create(
-                        users:   Users.Get(),
-                        clients: Clients.Get(),
-                        scopes:  Scopes.Get());
+                    var factory = new IdentityServerServiceFactory()
+                        .UseInMemoryUsers(Users.Get())
+                        .UseInMemoryClients(Clients.Get())
+                        .UseInMemoryScopes(Scopes.Get());
 
                     factory.CustomGrantValidator = 
                         new Registration<ICustomGrantValidator>(typeof(CustomGrantValidator));


### PR DESCRIPTION
I think this is nicer than the InMemFactory - and also gives you a chance to wire up the InMem CORS service in one go. 

We could switch all our helper methods to this approach.