### PR TITLE
When EnableWelcomePage is false, Welcome should be completely disabled 

### DIFF
--- a/source/Core/Configuration/Hosting/WebApiConfig.cs
+++ b/source/Core/Configuration/Hosting/WebApiConfig.cs
@@ -56,6 +56,11 @@ namespace IdentityServer3.Core.Configuration.Hosting
                 diag.TraceSource = liblog;                
             }
 
+            if (options.EnableWelcomePage)
+            {
+                config.Routes.MapHttpRoute(Constants.RouteNames.Welcome, Constants.RoutePaths.Welcome, new { controller = "Welcome", action = "Get" });
+            }
+
             if (options.LoggingOptions.EnableHttpLogging)
             {
                 config.MessageHandlers.Add(new RequestResponseLogger());

--- a/source/Core/Endpoints/WelcomeController.cs
+++ b/source/Core/Endpoints/WelcomeController.cs
@@ -17,7 +17,6 @@
 using IdentityServer3.Core.Configuration;
 using IdentityServer3.Core.Logging;
 using IdentityServer3.Core.Results;
-using System;
 using System.Net.Http;
 using System.Web.Http;
 
@@ -27,27 +26,13 @@ namespace IdentityServer3.Core.Endpoints
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 
-        private readonly IdentityServerOptions options;
-
-        public WelcomeController(IdentityServerOptions options)
+        public WelcomeController()
         {
-            if (options == null) throw new ArgumentNullException("options");
-
-            this.options = options;
         }
 
-        [Route(Constants.RoutePaths.Welcome, Name=Constants.RouteNames.Welcome)]
         public IHttpActionResult Get()
         {
-            Logger.Info("Welcome page requested");
-
-            if (!options.EnableWelcomePage)
-            {
-                Logger.Error("welcome page disabled, returning 404");
-                return NotFound();
-            }
-
-            Logger.Info("Rendering welcome page");
+            Logger.Info("Welcome page requested - rendering");
             return new WelcomeActionResult(Request.GetOwinContext());
         }
     }


### PR DESCRIPTION
This allow to override it with a custom page outside IdentityServer, for example with a MVC controller.

The change is basically adding a manual route to the welcome page only if `EnableWelcomePage` is **true** instead of relying on attributes.

Related issues #1413  #942