### PR TITLE
Add support for registering custom ApiController that are part of idsrv

### DIFF
--- a/source/Core/Configuration/IdentityServerOptions.cs
+++ b/source/Core/Configuration/IdentityServerOptions.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Web.Http;
 using IdentityServer3.Core.Logging;
 using Owin;
 using System;
@@ -44,6 +45,7 @@ namespace IdentityServer3.Core.Configuration
             this.LoggingOptions = new LoggingOptions();
             this.EventsOptions = new EventsOptions();
             this.EnableWelcomePage = true;
+            this.CustomApis = new List<Type>();
         }
 
         internal void Validate()
@@ -154,6 +156,12 @@ namespace IdentityServer3.Core.Configuration
         /// The plugin configuration.
         /// </value>
         public Action<IAppBuilder, IdentityServerOptions> PluginConfiguration { get; set; }
+
+        /// <summary>
+        /// Gets the additionals <see cref="ApiController"/> that should be added as part of the idsrv controllers
+        /// </summary>
+        /// <value>The additionals apis.</value>
+        public List<Type> CustomApis { get; private set; }
 
         /// <summary>
         /// Gets or sets the protocol logout urls.


### PR DESCRIPTION
There are scenarios (In my specific case, building an account service/server that is providing an integrated solution for registration, account edition, authentication, openid server...etc.) where we need to be able to easily add new webapis as part of IdentityServer.

This commit simply adds this possibility by adding a list of ApiController types as part of the `IdentityServerOptions`. This list is then used to expose the idsrv types plus these custom webapis.

Related to issue #812 (most notably discussion with @ChrisVinall)