### PR TITLE
Preserves the primary sign-in cookie on a partial sign-in

### DIFF
--- a/source/Core/Endpoints/AuthenticationController.cs
+++ b/source/Core/Endpoints/AuthenticationController.cs
@@ -668,7 +668,7 @@ namespace IdentityServer3.Core.Endpoints
         
         private IHttpActionResult SignInAndRedirect(SignInMessage signInMessage, string signInMessageId, AuthenticateResult authResult, bool? rememberMe = null)
         {
-            ClearAuthenticationCookies();
+            ClearAuthenticationCookiesForNewSignIn(authResult);
             IssueAuthenticationCookie(signInMessageId, authResult, rememberMe);
 
             var redirectUrl = GetRedirectUrl(signInMessage, authResult);
@@ -758,6 +758,18 @@ namespace IdentityServer3.Core.Endpoints
             {
                 return new Uri(signInMessage.ReturnUrl);
             }
+        }
+
+        private void ClearAuthenticationCookiesForNewSignIn(AuthenticateResult authResult)
+        {
+            // on a partial sign-in, preserve the existing primary sign-in
+            if (!authResult.IsPartialSignIn)
+            {
+                context.Authentication.SignOut(Constants.PrimaryAuthenticationType);
+            }
+            context.Authentication.SignOut(
+                Constants.ExternalAuthenticationType,
+                Constants.PartialSignInAuthenticationType);
         }
 
         private void ClearAuthenticationCookies()


### PR DESCRIPTION
Preserves the primary sign-in cookie on a partial sign-in because
 - A new "complete" sign-in was not performed so the last one should remain active
 - The access to the current sign-in is useful to enable the following scenario
   1. User is already signed-in on IdSrv
   2. User forces a new authentication flow (e.g by using "prompt=login")
   3. User uses a new external IdP
   4. On the callback, the UserManager service detects that the external id is not connected to any account and redirect to a "connect" resource
   5. The "connect" resource uses the current (preserved) primary id and the external id to ask the user if she wants to connect the external id to her account.

#1554