### PR TITLE
Using HttpResponseMessage for IViewService instead of a stream

### DIFF
--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -213,6 +213,7 @@
       <DependentUpon>T4resx.tt</DependentUpon>
     </Compile>
     <Compile Include="Results\CheckSessionResult.cs" />
+    <Compile Include="Results\AsyncResponseActionResult.cs" />
     <Compile Include="Results\RevocationErrorResult.cs" />
     <Compile Include="Results\WelcomeActionResult.cs" />
     <Compile Include="Services\Caching\CachingClientStore.cs" />

--- a/source/Core/Results/AsyncResponseActionResult.cs
+++ b/source/Core/Results/AsyncResponseActionResult.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace IdentityServer3.Core.Results
+{
+    internal abstract class AsyncResponseActionResult : IHttpActionResult
+    {
+        readonly Func<Task<HttpResponseMessage>> responseFunc;
+
+        public AsyncResponseActionResult(Func<Task<HttpResponseMessage>> responseFunc)
+        {
+            this.responseFunc = responseFunc;
+        }
+
+        public async Task<HttpResponseMessage> GetResponseMessage()
+        {
+            return await responseFunc();
+        }
+
+        public async Task<HttpResponseMessage> ExecuteAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            return await GetResponseMessage();
+        }
+    }
+}

--- a/source/Core/Results/ClientPermissionsActionResult.cs
+++ b/source/Core/Results/ClientPermissionsActionResult.cs
@@ -21,7 +21,7 @@ using System.Collections.Generic;
 
 namespace IdentityServer3.Core.Results
 {
-    internal class ClientPermissionsActionResult : HtmlStreamActionResult
+    internal class ClientPermissionsActionResult : AsyncResponseActionResult
     {
         public ClientPermissionsActionResult(IViewService viewSvc, IDictionary<string, object> env, ClientPermissionsViewModel model)
             : base(async () => await viewSvc.ClientPermissions(model))

--- a/source/Core/Results/ConsentActionResult.cs
+++ b/source/Core/Results/ConsentActionResult.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace IdentityServer3.Core.Results
 {
-    internal class ConsentActionResult : HtmlStreamActionResult
+    internal class ConsentActionResult : AsyncResponseActionResult
     {
         public ConsentActionResult(IViewService viewSvc, ConsentViewModel model, ValidatedAuthorizeRequest validatedRequest)
             : base(async () => await viewSvc.Consent(model, validatedRequest))

--- a/source/Core/Results/ErrorActionResult.cs
+++ b/source/Core/Results/ErrorActionResult.cs
@@ -20,7 +20,7 @@ using System;
 
 namespace IdentityServer3.Core.Results
 {
-    internal class ErrorActionResult : HtmlStreamActionResult
+    internal class ErrorActionResult : AsyncResponseActionResult
     {
         public ErrorActionResult(IViewService viewSvc, ErrorViewModel model)
             : base(async () => await viewSvc.Error(model))

--- a/source/Core/Results/HtmlActionResult.cs
+++ b/source/Core/Results/HtmlActionResult.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -40,6 +41,26 @@ namespace IdentityServer3.Core.Results
         public virtual Task<HttpResponseMessage> ExecuteAsync(System.Threading.CancellationToken cancellationToken)
         {
             return Task.FromResult(GetResponseMessage());
+        }
+    }
+
+    internal abstract class ResponseActionResult : IHttpActionResult
+    {
+        readonly Func<Task<HttpResponseMessage>> renderFunc;
+
+        public ResponseActionResult(Func<Task<HttpResponseMessage>> renderFunc)
+        {
+            this.renderFunc = renderFunc;
+        }
+
+        public async Task<HttpResponseMessage> GetResponseMessage()
+        {
+            return await renderFunc();
+        }
+
+        public async Task<HttpResponseMessage> ExecuteAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            return await GetResponseMessage();
         }
     }
 }

--- a/source/Core/Results/LoggedOutActionResult.cs
+++ b/source/Core/Results/LoggedOutActionResult.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace IdentityServer3.Core.Results
 {
-    internal class LoggedOutActionResult : HtmlStreamActionResult
+    internal class LoggedOutActionResult : AsyncResponseActionResult
     {
         public LoggedOutActionResult(IViewService viewSvc, LoggedOutViewModel model, SignOutMessage message)
             : base(async () => await viewSvc.LoggedOut(model, message))

--- a/source/Core/Results/LoginActionResult.cs
+++ b/source/Core/Results/LoginActionResult.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace IdentityServer3.Core.Results
 {
-    internal class LoginActionResult : HtmlStreamActionResult
+    internal class LoginActionResult : AsyncResponseActionResult
     {
         public LoginActionResult(IViewService viewSvc, LoginViewModel model, SignInMessage message)
             : base(async () => await viewSvc.Login(model, message))

--- a/source/Core/Results/LogoutActionResult.cs
+++ b/source/Core/Results/LogoutActionResult.cs
@@ -21,7 +21,7 @@ using System;
 
 namespace IdentityServer3.Core.Results
 {
-    internal class LogoutActionResult : HtmlStreamActionResult
+    internal class LogoutActionResult : AsyncResponseActionResult
     {
         public LogoutActionResult(IViewService viewSvc, LogoutViewModel model, SignOutMessage message)
             : base(async () => await viewSvc.Logout(model, message))

--- a/source/Core/Services/DefaultViewService/DefaultViewService.cs
+++ b/source/Core/Services/DefaultViewService/DefaultViewService.cs
@@ -22,6 +22,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -92,7 +93,7 @@ namespace IdentityServer3.Core.Services.Default
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        public virtual Task<Stream> Login(LoginViewModel model, SignInMessage message)
+        public virtual Task<HttpResponseMessage> Login(LoginViewModel model, SignInMessage message)
         {
             return Render(model, LoginView);
         }
@@ -105,7 +106,7 @@ namespace IdentityServer3.Core.Services.Default
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        public virtual Task<Stream> Logout(LogoutViewModel model, SignOutMessage message)
+        public virtual Task<HttpResponseMessage> Logout(LogoutViewModel model, SignOutMessage message)
         {
             return Render(model, LogoutView);
         }
@@ -118,7 +119,7 @@ namespace IdentityServer3.Core.Services.Default
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        public virtual Task<Stream> LoggedOut(LoggedOutViewModel model, SignOutMessage message)
+        public virtual Task<HttpResponseMessage> LoggedOut(LoggedOutViewModel model, SignOutMessage message)
         {
             return Render(model, LoggedOutView);
         }
@@ -131,7 +132,7 @@ namespace IdentityServer3.Core.Services.Default
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        public virtual Task<Stream> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest)
+        public virtual Task<HttpResponseMessage> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest)
         {
             return Render(model, ConsentView);
         }
@@ -143,7 +144,7 @@ namespace IdentityServer3.Core.Services.Default
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        public Task<Stream> ClientPermissions(ClientPermissionsViewModel model)
+        public Task<HttpResponseMessage> ClientPermissions(ClientPermissionsViewModel model)
         {
             return Render(model, ClientPermissionsView);
         }
@@ -155,7 +156,7 @@ namespace IdentityServer3.Core.Services.Default
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        public virtual Task<Stream> Error(ErrorViewModel model)
+        public virtual Task<HttpResponseMessage> Error(ErrorViewModel model)
         {
             return Render(model, ErrorView);
         }
@@ -166,9 +167,29 @@ namespace IdentityServer3.Core.Services.Default
         /// <param name="model">The model.</param>
         /// <param name="page">The page.</param>
         /// <returns></returns>
-        protected virtual Task<Stream> Render(CommonViewModel model, string page)
+        protected virtual async Task<HttpResponseMessage> Render(CommonViewModel model, string page)
         {
-            return Render(model, page, config.Stylesheets, config.Scripts);
+            var stream = await Render(model, page, config.Stylesheets, config.Scripts);
+            return CreateHttpResponseMessage(stream);
+        }
+
+        /// <summary>
+        /// Converts the page stream to a HttpResponseMessage
+        /// </summary>
+        /// <param name="stream">The page stream</param>
+        /// <returns></returns>
+        protected virtual HttpResponseMessage CreateHttpResponseMessage(Stream stream)
+        {
+            var content = new StreamContent(stream);
+            content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("text/html")
+            {
+                CharSet = Encoding.UTF8.WebName
+            };
+
+            return new HttpResponseMessage
+            {
+                Content = content
+            };
         }
 
         /// <summary>

--- a/source/Core/Services/IViewService.cs
+++ b/source/Core/Services/IViewService.cs
@@ -18,6 +18,7 @@ using IdentityServer3.Core.Models;
 using IdentityServer3.Core.Validation;
 using IdentityServer3.Core.ViewModels;
 using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace IdentityServer3.Core.Services
@@ -33,7 +34,7 @@ namespace IdentityServer3.Core.Services
         /// <param name="model">The model.</param>
         /// <param name="message">The message.</param>
         /// <returns>Stream for the HTML</returns>
-        Task<Stream> Login(LoginViewModel model, SignInMessage message);
+        Task<HttpResponseMessage> Login(LoginViewModel model, SignInMessage message);
 
         /// <summary>
         /// Loads the HTML for the logout prompt page.
@@ -43,7 +44,7 @@ namespace IdentityServer3.Core.Services
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        Task<Stream> Logout(LogoutViewModel model, SignOutMessage message);
+        Task<HttpResponseMessage> Logout(LogoutViewModel model, SignOutMessage message);
 
         /// <summary>
         /// Loads the HTML for the logged out page informing the user that they have successfully logged out.
@@ -53,7 +54,7 @@ namespace IdentityServer3.Core.Services
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        Task<Stream> LoggedOut(LoggedOutViewModel model, SignOutMessage message);
+        Task<HttpResponseMessage> LoggedOut(LoggedOutViewModel model, SignOutMessage message);
 
         /// <summary>
         /// Loads the HTML for the user consent page.
@@ -63,20 +64,20 @@ namespace IdentityServer3.Core.Services
         /// <returns>
         /// Stream for the HTML
         /// </returns>
-        Task<Stream> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest);
+        Task<HttpResponseMessage> Consent(ConsentViewModel model, ValidatedAuthorizeRequest authorizeRequest);
 
         /// <summary>
         /// Loads the HTML for the client permissions page.
         /// </summary>
         /// <param name="model">The model.</param>
         /// <returns>Stream for the HTML</returns>
-        Task<Stream> ClientPermissions(ClientPermissionsViewModel model);
+        Task<HttpResponseMessage> ClientPermissions(ClientPermissionsViewModel model);
 
         /// <summary>
         /// Loads the HTML for the error page.
         /// </summary>
         /// <param name="model">The model.</param>
         /// <returns>Stream for the HTML</returns>
-        Task<Stream> Error(ErrorViewModel model);
+        Task<HttpResponseMessage> Error(ErrorViewModel model);
     }
 }


### PR DESCRIPTION
I would like to implemented a nicer logout action for my custom view, where I redirect immediately from the server to my client instead of using a javascript redirect. This is currently not possible, because the actual views are being returned as a stream. IMO it would make sense if this was a HttpResponseMessage instead. That way, you can also configure headers and such.