### PR TITLE
Update AuthorizeRequestValidator.cs

### DIFF
--- a/source/Core/Validation/AuthorizeRequestValidator.cs
+++ b/source/Core/Validation/AuthorizeRequestValidator.cs
@@ -354,13 +354,12 @@ namespace IdentityServer3.Core.Validation
             }
             else
             {
-                if (request.Flow == Flows.Implicit ||
-                    request.Flow == Flows.Hybrid)
+                if (request.Flow == Flows.Implicit)
                 {
-                    // only openid requests require nonce
+                    // only an Implicit Flow openid requests require nonce (see http://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthRequest)
                     if (request.IsOpenIdRequest)
                     {
-                        LogError("Nonce required for implicit and hybrid flow with openid scope", request);
+                        LogError("Nonce required for implicit flow with openid scope", request);
                         return Invalid(request, ErrorTypes.Client);
                     }
                 }


### PR DESCRIPTION
Do not require a nonce for Hybrid Flow Authorization Requests, as per section 3.3.2.1 of the OpenID Connect spec (http://openid.net/specs/openid-connect-core-1_0.html#HybridAuthRequest)
#1742