### PR TITLE
use Autofac's extension Assembly.GetLoadableTypes() instead of .GetTy…

### DIFF
--- a/source/Core/Configuration/Hosting/WebApiConfig.cs
+++ b/source/Core/Configuration/Hosting/WebApiConfig.cs
@@ -16,6 +16,7 @@
 
 using Autofac;
 using Autofac.Integration.WebApi;
+using Autofac.Util;
 using IdentityServer3.Core.Logging;
 using System;
 using System.Collections.Generic;
@@ -53,7 +54,7 @@ namespace IdentityServer3.Core.Configuration.Hosting
 
                 var diag = config.EnableSystemDiagnosticsTracing();
                 diag.IsVerbose = options.LoggingOptions.WebApiDiagnosticsIsVerbose;
-                diag.TraceSource = liblog;                
+                diag.TraceSource = liblog;
             }
 
             ConfigureRoutes(options, config);
@@ -76,7 +77,7 @@ namespace IdentityServer3.Core.Configuration.Hosting
                 var httpControllerType = typeof (IHttpController);
                 return typeof (WebApiConfig)
                     .Assembly
-                    .GetTypes()
+                    .GetLoadableTypes()
                     .Where(t => t.IsClass && !t.IsAbstract && httpControllerType.IsAssignableFrom(t))
                     .ToList();
             }


### PR DESCRIPTION
…pes().

- Avoids exceptions on mono
- Addresses #1443