### PR TITLE
Add support for cookie session store

### DIFF
--- a/source/Core/Configuration/AppBuilderExtensions/ConfigureCookieAuthenticationExtension.cs
+++ b/source/Core/Configuration/AppBuilderExtensions/ConfigureCookieAuthenticationExtension.cs
@@ -44,7 +44,8 @@ namespace Owin
                 ExpireTimeSpan = options.ExpireTimeSpan,
                 SlidingExpiration = options.SlidingExpiration,
                 CookieSecure = GetCookieSecure(options.SecureMode),
-                TicketDataFormat = new TicketDataFormat(new DataProtectorAdapter(dataProtector, options.Prefix + Constants.PrimaryAuthenticationType))
+                TicketDataFormat = new TicketDataFormat(new DataProtectorAdapter(dataProtector, options.Prefix + Constants.PrimaryAuthenticationType)),
+                SessionStore = GetSessionStore(options.SessionStoreProvider)
             };
             app.UseCookieAuthentication(primary);
 
@@ -115,6 +116,11 @@ namespace Owin
                 default:
                     throw new InvalidOperationException("Invalid CookieSecureMode");
             }
+        }
+
+        private static IAuthenticationSessionStore GetSessionStore(IAuthenticationSessionStoreProvider provider)
+        {
+            return provider != null ? new AuthenticationSessionStoreWrapper(provider) : null;
         }
     }
 }

--- a/source/Core/Configuration/AuthenticationSessionStoreWrapper.cs
+++ b/source/Core/Configuration/AuthenticationSessionStoreWrapper.cs
@@ -16,24 +16,17 @@
 
         public Task<string> StoreAsync(AuthenticationTicket ticket)
         {
-            return this.provider.StoreAsync(ticket.Identity);
+            return this.provider.StoreAsync(ticket);
         }
 
         public Task RenewAsync(string key, AuthenticationTicket ticket)
         {
-            return this.provider.RenewAsync(key, ticket.Identity);
+            return this.provider.RenewAsync(key, ticket);
         }
 
-        public async Task<AuthenticationTicket> RetrieveAsync(string key)
+        public Task<AuthenticationTicket> RetrieveAsync(string key)
         {
-            var identity = await this.provider.RetrieveAsync(key);
-            if (identity == null)
-            {
-                return null;
-            }
-
-            var properties = new AuthenticationProperties();
-            return new AuthenticationTicket(identity, properties);
+            return this.provider.RetrieveAsync(key);
         }
 
         public Task RemoveAsync(string key)

--- a/source/Core/Configuration/AuthenticationSessionStoreWrapper.cs
+++ b/source/Core/Configuration/AuthenticationSessionStoreWrapper.cs
@@ -16,17 +16,18 @@
 
         public Task<string> StoreAsync(AuthenticationTicket ticket)
         {
-            return this.provider.StoreAsync(ticket);
+            return this.provider.StoreAsync(new AuthenticationTicketModel(ticket));
         }
 
         public Task RenewAsync(string key, AuthenticationTicket ticket)
         {
-            return this.provider.RenewAsync(key, ticket);
+            return this.provider.RenewAsync(key, new AuthenticationTicketModel(ticket));
         }
 
-        public Task<AuthenticationTicket> RetrieveAsync(string key)
+        public async Task<AuthenticationTicket> RetrieveAsync(string key)
         {
-            return this.provider.RetrieveAsync(key);
+            var ticket = await this.provider.RetrieveAsync(key);
+            return ticket == null ? null : ticket.ToAuthenticationTicket();
         }
 
         public Task RemoveAsync(string key)

--- a/source/Core/Configuration/AuthenticationSessionStoreWrapper.cs
+++ b/source/Core/Configuration/AuthenticationSessionStoreWrapper.cs
@@ -1,0 +1,44 @@
+﻿namespace IdentityServer3.Core.Configuration
+{
+    using System.Threading.Tasks;
+
+    using Microsoft.Owin.Security;
+    using Microsoft.Owin.Security.Cookies;
+
+    internal class AuthenticationSessionStoreWrapper : IAuthenticationSessionStore
+    {
+        private readonly IAuthenticationSessionStoreProvider provider;
+
+        public AuthenticationSessionStoreWrapper(IAuthenticationSessionStoreProvider provider)
+        {
+            this.provider = provider;
+        }
+
+        public Task<string> StoreAsync(AuthenticationTicket ticket)
+        {
+            return this.provider.StoreAsync(ticket.Identity);
+        }
+
+        public Task RenewAsync(string key, AuthenticationTicket ticket)
+        {
+            return this.provider.RenewAsync(key, ticket.Identity);
+        }
+
+        public async Task<AuthenticationTicket> RetrieveAsync(string key)
+        {
+            var identity = await this.provider.RetrieveAsync(key);
+            if (identity == null)
+            {
+                return null;
+            }
+
+            var properties = new AuthenticationProperties();
+            return new AuthenticationTicket(identity, properties);
+        }
+
+        public Task RemoveAsync(string key)
+        {
+            return this.provider.RemoveAsync(key);
+        }
+    }
+}

--- a/source/Core/Configuration/AuthenticationTicketModel.cs
+++ b/source/Core/Configuration/AuthenticationTicketModel.cs
@@ -1,0 +1,42 @@
+namespace IdentityServer3.Core.Configuration
+{
+    using System.Collections.Generic;
+    using System.Security.Claims;
+
+    using Microsoft.Owin.Security;
+
+    /// <summary>
+    /// A model class represending an authentication ticket
+    /// </summary>
+    public class AuthenticationTicketModel
+    {
+        /// <summary>
+        /// Instantiates an instance of authentication ticket
+        /// </summary>
+        public AuthenticationTicketModel(ClaimsIdentity identity, IDictionary<string, string> properties)
+        {
+            this.Identity = identity;
+            this.Properties = properties;
+        }
+
+        internal AuthenticationTicketModel(AuthenticationTicket ticket)
+            : this(ticket.Identity, ticket.Properties.Dictionary)
+        {
+        }
+
+        /// <summary>
+        /// The claims identity of the authentication ticket
+        /// </summary>
+        public ClaimsIdentity Identity { get; private set; }
+
+        /// <summary>
+        /// Authentication ticket properties
+        /// </summary>
+        public IDictionary<string, string> Properties { get; private set; }
+
+        internal AuthenticationTicket ToAuthenticationTicket()
+        {
+            return new AuthenticationTicket(this.Identity, new AuthenticationProperties(this.Properties));
+        }
+    }
+}

--- a/source/Core/Configuration/CookieOptions.cs
+++ b/source/Core/Configuration/CookieOptions.cs
@@ -100,5 +100,11 @@ namespace IdentityServer3.Core.Configuration
         /// The secure.
         /// </value>
         public CookieSecureMode SecureMode { get; set; }
+
+        /// <summary>
+        /// An optional container in which to store the identity across requests. When used, only a session identifier is sent
+        /// to the client. This can be used to mitigate potential problems with very large identities.
+        /// </summary>
+        public IAuthenticationSessionStoreProvider SessionStoreProvider { get; set; }
     }
 }

--- a/source/Core/Configuration/IAuthenticationSessionStoreProvider.cs
+++ b/source/Core/Configuration/IAuthenticationSessionStoreProvider.cs
@@ -1,7 +1,8 @@
 namespace IdentityServer3.Core.Configuration
 {
-    using System.Security.Claims;
     using System.Threading.Tasks;
+
+    using Microsoft.Owin.Security;
 
     /// <summary>
     /// Providers the authentication session stores functions
@@ -12,29 +13,29 @@ namespace IdentityServer3.Core.Configuration
         /// Provides the remove functionality of session store
         /// </summary>
         /// <param name="key">Session key</param>
-        /// <returns>async Task</returns>
+        /// <returns>Async task</returns>
         Task RemoveAsync(string key);
 
         /// <summary>
         /// Provides the renew functionality of session store
         /// </summary>
         /// <param name="key">Session key</param>
-        /// <param name="identity">Auth identity</param>
-        /// <returns>async Task</returns>
-        Task RenewAsync(string key, ClaimsIdentity identity);
+        /// <param name="identity">Authentication ticket</param>
+        /// <returns>Async task</returns>
+        Task RenewAsync(string key, AuthenticationTicket identity);
 
         /// <summary>
         /// Provides the retrieve functionality of session store
         /// </summary>
         /// <param name="key">Session key</param>
-        /// <returns>async Task with identity</returns>
-        Task<ClaimsIdentity> RetrieveAsync(string key);
+        /// <returns>Async task with authentication ticket result</returns>
+        Task<AuthenticationTicket> RetrieveAsync(string key);
 
         /// <summary>
         /// Provides the store functionality of session store
         /// </summary>
-        /// <param name="ticket">Auth ticket</param>
-        /// <returns>async task with session key</returns>
-        Task<string> StoreAsync(ClaimsIdentity ticket);
+        /// <param name="ticket">Authentication ticket</param>
+        /// <returns>Async task with session key</returns>
+        Task<string> StoreAsync(AuthenticationTicket ticket);
     }
 }

--- a/source/Core/Configuration/IAuthenticationSessionStoreProvider.cs
+++ b/source/Core/Configuration/IAuthenticationSessionStoreProvider.cs
@@ -2,8 +2,6 @@ namespace IdentityServer3.Core.Configuration
 {
     using System.Threading.Tasks;
 
-    using Microsoft.Owin.Security;
-
     /// <summary>
     /// Providers the authentication session stores functions
     /// </summary>
@@ -22,20 +20,20 @@ namespace IdentityServer3.Core.Configuration
         /// <param name="key">Session key</param>
         /// <param name="identity">Authentication ticket</param>
         /// <returns>Async task</returns>
-        Task RenewAsync(string key, AuthenticationTicket identity);
+        Task RenewAsync(string key, AuthenticationTicketModel identity);
 
         /// <summary>
         /// Provides the retrieve functionality of session store
         /// </summary>
         /// <param name="key">Session key</param>
         /// <returns>Async task with authentication ticket result</returns>
-        Task<AuthenticationTicket> RetrieveAsync(string key);
+        Task<AuthenticationTicketModel> RetrieveAsync(string key);
 
         /// <summary>
         /// Provides the store functionality of session store
         /// </summary>
         /// <param name="ticket">Authentication ticket</param>
         /// <returns>Async task with session key</returns>
-        Task<string> StoreAsync(AuthenticationTicket ticket);
+        Task<string> StoreAsync(AuthenticationTicketModel ticket);
     }
 }

--- a/source/Core/Configuration/IAuthenticationSessionStoreProvider.cs
+++ b/source/Core/Configuration/IAuthenticationSessionStoreProvider.cs
@@ -1,0 +1,40 @@
+namespace IdentityServer3.Core.Configuration
+{
+    using System.Security.Claims;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Providers the authentication session stores functions
+    /// </summary>
+    public interface IAuthenticationSessionStoreProvider
+    {
+        /// <summary>
+        /// Provides the remove functionality of session store
+        /// </summary>
+        /// <param name="key">Session key</param>
+        /// <returns>async Task</returns>
+        Task RemoveAsync(string key);
+
+        /// <summary>
+        /// Provides the renew functionality of session store
+        /// </summary>
+        /// <param name="key">Session key</param>
+        /// <param name="identity">Auth identity</param>
+        /// <returns>async Task</returns>
+        Task RenewAsync(string key, ClaimsIdentity identity);
+
+        /// <summary>
+        /// Provides the retrieve functionality of session store
+        /// </summary>
+        /// <param name="key">Session key</param>
+        /// <returns>async Task with identity</returns>
+        Task<ClaimsIdentity> RetrieveAsync(string key);
+
+        /// <summary>
+        /// Provides the store functionality of session store
+        /// </summary>
+        /// <param name="ticket">Auth ticket</param>
+        /// <returns>async task with session key</returns>
+        Task<string> StoreAsync(ClaimsIdentity ticket);
+    }
+}

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -130,9 +130,11 @@
     <Compile Include="Configuration\AppBuilderExtensions\ConfigureIdentityServerIssuerExtension.cs" />
     <Compile Include="Configuration\AppBuilderExtensions\ConfigureRequestIdExtension.cs" />
     <Compile Include="Configuration\AppBuilderExtensions\ConfigureHttpLoggingExtension.cs" />
+    <Compile Include="Configuration\AuthenticationSessionStoreWrapper.cs" />
     <Compile Include="Configuration\CookieSecureMode.cs" />
     <Compile Include="Configuration\EventsOptions.cs" />
     <Compile Include="Configuration\InputLengthRestrictions.cs" />
+    <Compile Include="Configuration\IAuthenticationSessionStoreProvider.cs" />
     <Compile Include="Configuration\X509CertificateDataProtector.cs" />
     <Compile Include="Endpoints\Connect\RevocationEndpointController.cs" />
     <Compile Include="Endpoints\WelcomeController.cs" />

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -131,6 +131,7 @@
     <Compile Include="Configuration\AppBuilderExtensions\ConfigureRequestIdExtension.cs" />
     <Compile Include="Configuration\AppBuilderExtensions\ConfigureHttpLoggingExtension.cs" />
     <Compile Include="Configuration\AuthenticationSessionStoreWrapper.cs" />
+    <Compile Include="Configuration\AuthenticationTicketModel.cs" />
     <Compile Include="Configuration\CookieSecureMode.cs" />
     <Compile Include="Configuration\EventsOptions.cs" />
     <Compile Include="Configuration\InputLengthRestrictions.cs" />


### PR DESCRIPTION
@tarunvd @flytzen

Re: #1683 

We came up across this scenario where we need to set the session store to be used for cookie authentication that IdentityServer utilizes.

This change set aims to add support for this.

<!---
@huboard:{"order":1018.2119140625,"milestone_order":1839,"custom_state":""}
-->
