### PR TITLE
Scrub user passwords from logs

### DIFF
--- a/source/Core/Endpoints/Connect/TokenEndpointController.cs
+++ b/source/Core/Endpoints/Connect/TokenEndpointController.cs
@@ -92,7 +92,7 @@ namespace IdentityServer3.Core.Endpoints
         /// </summary>
         /// <param name="parameters">The parameters.</param>
         /// <returns>Token response</returns>
-        public async Task<IHttpActionResult> ProcessAsync(NameValueCollection parameters)
+        private async Task<IHttpActionResult> ProcessAsync(NameValueCollection parameters)
         {
             // validate client credentials and client
             var clientResult = await _clientValidator.ValidateAsync();

--- a/source/Core/Logging/Models/TokenRequestValidationLog.cs
+++ b/source/Core/Logging/Models/TokenRequestValidationLog.cs
@@ -37,9 +37,16 @@ namespace IdentityServer3.Core.Logging
 
         public Dictionary<string, string> Raw { get; set; }
 
-        public TokenRequestValidationLog(ValidatedTokenRequest request)
+        public TokenRequestValidationLog(ValidatedTokenRequest request, bool scrubSensitiveData)
         {
+            const string scrubValue = "**********";
+
             Raw = request.Raw.ToDictionary();
+
+            if (scrubSensitiveData && Raw.ContainsKey(Constants.TokenRequest.Password))
+            {
+                Raw[Constants.TokenRequest.Password] = scrubValue;
+            }
 
             if (request.Client != null)
             {

--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -680,26 +680,28 @@ namespace IdentityServer3.Core.Validation
 
         private void LogError(string message)
         {
-            var validationLog = new TokenRequestValidationLog(_validatedRequest);
-            var json = LogSerializer.Serialize(validationLog);
-
-            Logger.ErrorFormat("{0}\n {1}", message, json);
+            Logger.Error(LogEvent(message));
         }
 
         private void LogWarn(string message)
         {
-            var validationLog = new TokenRequestValidationLog(_validatedRequest);
-            var json = LogSerializer.Serialize(validationLog);
-
-            Logger.WarnFormat("{0}\n {1}", message, json);
+            Logger.Warn(LogEvent(message));
         }
 
         private void LogSuccess()
         {
-            var validationLog = new TokenRequestValidationLog(_validatedRequest);
-            var json = LogSerializer.Serialize(validationLog);
+            Logger.Info(LogEvent("Token request validation success"));
+        }
 
-            Logger.InfoFormat("{0}\n {1}", "Token request validation success", json);
+        private Func<string> LogEvent(string message)
+        {
+            return () =>
+            {
+                var validationLog = new TokenRequestValidationLog(_validatedRequest, true);
+                var json = LogSerializer.Serialize(validationLog);
+
+                return string.Format("{0}\n {1}", message, json);
+            };
         }
 
         private async Task RaiseSuccessfulResourceOwnerAuthenticationEventAsync(string userName, string subjectId, SignInMessage signInMessage)


### PR DESCRIPTION
Closes #2038.

I added a ctor parameter to `TokenRequestValidationLog` to configure whether to scrub user passwords. This should be expanded to expose this configuration through the `LoggingOptions` but I wasn't sure if you wanted to make that change yet because it would effectively change the API -- though it is an addition to the interface, thus making it backwards compat.

Also, I refactored the logging to not serialize unless the logger is configured for that log level.