### PR TITLE
Filter sensitive data from log

### DIFF
--- a/source/Core/Constants.cs
+++ b/source/Core/Constants.cs
@@ -80,6 +80,7 @@ namespace IdentityServer3.Core
             public const string RedirectUri  = "redirect_uri";
             public const string ClientId     = "client_id";
             public const string ClientSecret = "client_secret";
+            public const string ClientAssertion = "client_assertion";
             public const string Assertion    = "assertion";
             public const string Code         = "code";
             public const string RefreshToken = "refresh_token";

--- a/source/Core/Logging/Models/TokenRequestValidationLog.cs
+++ b/source/Core/Logging/Models/TokenRequestValidationLog.cs
@@ -17,6 +17,7 @@
 using IdentityServer3.Core.Extensions;
 using IdentityServer3.Core.Validation;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace IdentityServer3.Core.Logging
 {
@@ -37,14 +38,23 @@ namespace IdentityServer3.Core.Logging
 
         public Dictionary<string, string> Raw { get; set; }
 
+        private static IReadOnlyCollection<string> SensitiveData = new List<string>()
+            {
+                Constants.TokenRequest.Password,
+                Constants.TokenRequest.Assertion,
+                Constants.TokenRequest.ClientSecret,
+                Constants.TokenRequest.ClientAssertion
+            };
+
         public TokenRequestValidationLog(ValidatedTokenRequest request)
         {
             const string scrubValue = "******";
+            
             Raw = request.Raw.ToDictionary();
-
-            if (Raw.ContainsKey(Constants.TokenRequest.Password))
+            
+            foreach (var field in SensitiveData.Where(field => Raw.ContainsKey(field)))
             {
-                Raw[Constants.TokenRequest.Password] = scrubValue;
+                Raw[field] = scrubValue;
             }
 
             if (request.Client != null)


### PR DESCRIPTION
Filtering out values of "client_secret", "client_assertion" and "assertion" in the token request (in addition to "password").

Maybe filter out "code" too?