### PR TITLE
Force C# 5 syntax in Core

### DIFF
--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -24,6 +24,7 @@
     <DocumentationFile>..\..\build\IdentityServer3.xml</DocumentationFile>
     <NoWarn>
     </NoWarn>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
Since c# 6 is not allowed, let's make it explicit.