### PR TITLE
TokenRequest should not be honoured if custom grant validator throws

### DIFF
--- a/source/Core/Validation/CustomGrantValidator.cs
+++ b/source/Core/Validation/CustomGrantValidator.cs
@@ -49,7 +49,7 @@ namespace IdentityServer3.Core.Validation
                 return new CustomGrantValidationResult
                 {
                     IsError = true,
-                    ErrorDescription = "No validator found for grant type"
+                    Error = "No validator found for grant type"
                 };
 
             try
@@ -62,7 +62,7 @@ namespace IdentityServer3.Core.Validation
                 return new CustomGrantValidationResult
                 {
                     IsError = true,
-                    ErrorDescription = "Grant validation error"
+                    Error = "Grant validation error",
                 };
             }
         }

--- a/source/Tests/UnitTests/Validation/CustomGrantValidation.cs
+++ b/source/Tests/UnitTests/Validation/CustomGrantValidation.cs
@@ -48,7 +48,7 @@ namespace IdentityServer3.Tests.Validation
             var result = await validator.ValidateAsync(request);
 
             result.IsError.Should().BeTrue();
-            result.ErrorDescription.Should().Be("Grant validation error");
+            result.Error.Should().Be("Grant validation error");
             result.Principal.Should().BeNull();
             
         }

--- a/source/Tests/UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_CustomGrants_Invalid.cs
+++ b/source/Tests/UnitTests/Validation/TokenRequest Validation/TokenRequestValidation_CustomGrants_Invalid.cs
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 
+using System;
 using FluentAssertions;
 using IdentityServer3.Core;
 using IdentityServer3.Core.Services;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
+using IdentityServer3.Core.Validation;
+using Moq;
 using Xunit;
 
 namespace IdentityServer3.Tests.Validation.TokenRequest
@@ -64,5 +67,34 @@ namespace IdentityServer3.Tests.Validation.TokenRequest
             result.IsError.Should().BeTrue();
             result.Error.Should().Be(Constants.TokenErrors.UnsupportedGrantType);
         }
+
+        [Fact]
+        [Trait("Category", Category)]
+        public async Task Failing_Custom_Grant_Validator()
+        {
+            var grantType = "custom_grant";
+            var client = await _clients.FindClientByIdAsync("customgrantclient");
+
+            var validator = Factory.CreateTokenRequestValidator(customGrantValidators: new[] { AlwaysFailingCustomGrantValidator(grantType).Object });
+
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.TokenRequest.GrantType, grantType);
+            parameters.Add(Constants.TokenRequest.Scope, "resource");
+
+            var result = await validator.ValidateRequestAsync(parameters, client);
+
+            result.IsError.Should().BeTrue();
+            result.Error.Should().Be("Grant validation error");
+        }
+
+        private static Mock<ICustomGrantValidator> AlwaysFailingCustomGrantValidator(string grantType)
+        {
+            var alwaysFailingCustomGrantValidator = new Mock<ICustomGrantValidator>();
+            alwaysFailingCustomGrantValidator.Setup(y => y.ValidateAsync(It.IsAny<ValidatedTokenRequest>()))
+                .Throws<NotSupportedException>();
+            alwaysFailingCustomGrantValidator.SetupGet(y => y.GrantType).Returns(grantType);
+            return alwaysFailingCustomGrantValidator;
+        }
+
     }
 }


### PR DESCRIPTION
TokenRequest would not detect that custom grant validation has failed, because `IsError` field is ignored by the `TokenRequestValidator`.  Validation routine only checks whether `Error` property is set, and ignores 'IsError', validation routine [code is here](https://github.com/IdentityServer/IdentityServer3/blob/f7856c12791289e4864d817caeb0c38f512c68ac/source/Core/Validation/TokenRequestValidator.cs#L634)

This does raise a question what is the meaning of this code  (this is of course out of scope of this PR)
````
 return new CustomGrantValidationResult
{
   IsError = false,   // Not an error
   ErrorDescription = "No validator found for grant type" // This is an error
};
````

