### PR TITLE
Fix client_assertion_type handling in ClientAssertionSecretParser

### DIFF
--- a/source/Core/Constants.cs
+++ b/source/Core/Constants.cs
@@ -130,6 +130,11 @@ namespace IdentityServer3.Core
             public const string JwtBearer   = "urn:ietf:params:oauth:grant-type:jwt-bearer";
         }
 
+        public static class ClientAssertionTypes
+        {
+            public const string JwtBearer   = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
+        }
+
         public static class ResponseTypes
         {
             // authorization code flow
@@ -584,7 +589,7 @@ namespace IdentityServer3.Core
         {
             public const string SharedSecret = "SharedSecret";
             public const string X509Certificate = "X509Certificate";
-            public const string JwtBearer = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+            public const string JwtBearer = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
         }
 
         public static class SecretTypes

--- a/source/Core/Validation/ClientAssertionSecretParser.cs
+++ b/source/Core/Validation/ClientAssertionSecretParser.cs
@@ -55,7 +55,7 @@ namespace IdentityServer3.Core.Validation
                 var clientAssertion = body.Get(Constants.TokenRequest.ClientAssertion);
 
                 if (clientAssertion.IsPresent()
-                    && clientAssertionType == Constants.GrantTypes.JwtBearer)
+                    && clientAssertionType == Constants.ClientAssertionTypes.JwtBearer)
                 {
                     if (!clientId.IsPresent())
                     {

--- a/source/Tests/UnitTests/Validation/Secrets/ClientAssertionSecretParsing.cs
+++ b/source/Tests/UnitTests/Validation/Secrets/ClientAssertionSecretParsing.cs
@@ -53,7 +53,7 @@ namespace IdentityServer3.Tests.Validation.Secrets
         {
             var context = new OwinContext();
 
-            var body = "client_id=client&client_assertion_type=urn:ietf:params:oauth:grant-type:jwt-bearer&client_assertion=token";
+            var body = "client_id=client&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=token";
 
             context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
 
@@ -73,7 +73,7 @@ namespace IdentityServer3.Tests.Validation.Secrets
             var token = new JwtSecurityToken(issuer: "client");
             var tokenString = new JwtSecurityTokenHandler().WriteToken(token);
 
-            var body = "client_assertion_type=urn:ietf:params:oauth:grant-type:jwt-bearer&client_assertion=" + tokenString;
+            var body = "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer&client_assertion=" + tokenString;
 
             context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
 


### PR DESCRIPTION
Bugfix for #2233

I was now switching from my local implementation to the one shipped in v2.3 and noticed I messed up with the constants a bit. This fixes it.