### PR TITLE
Clear partial login cookies on error in PostAuthenticateAsync processing

### DIFF
--- a/source/Core/Endpoints/AuthenticationController.cs
+++ b/source/Core/Endpoints/AuthenticationController.cs
@@ -717,6 +717,7 @@ namespace IdentityServer3.Core.Endpoints
                 if (authResult.IsError)
                 {
                     Logger.WarnFormat("user service PostAuthenticateAsync returned an error message: {0}", authResult.ErrorMessage);
+                    ClearAuthenticationCookiesForNewSignIn(authResult);
                     return new Tuple<IHttpActionResult, AuthenticateResult>(RenderErrorPage(authResult.ErrorMessage), null);
                 }
 

--- a/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
+++ b/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
@@ -703,7 +703,9 @@ namespace IdentityServer3.Tests.Endpoints
             resp.AssertPage("error");
 
             var cookies = resp.GetRawCookies();
-            cookies.Count(x => x.StartsWith(Constants.PrimaryAuthenticationType + "=")).Should().Be(0);
+            cookies.Count(x => x.StartsWith(Constants.PrimaryAuthenticationType + "=")).Should().Be(1);
+            cookies.Count(x => x.StartsWith(Constants.PartialSignInAuthenticationType + "=")).Should().Be(1);
+            cookies.Count(x => x.StartsWith(Constants.ExternalAuthenticationType + "=")).Should().Be(1);
         }
 
         [Fact]


### PR DESCRIPTION
-  During partial login when an error occurs in a custom user service clear the partial authentication cookies, this allows the user service to require starting all over in the login process.