### PR TITLE
Allowed middleware registered externally to use partial signins via cookie authentication

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -64,7 +64,8 @@ task ILMerge -depends Compile {
 		foreach-object {
 			# Exclude IdentityServer3.dll as that will be the primary assembly
 			if ("$_" -ne "IdentityServer3.dll" -and
-			    "$_" -ne "Owin.dll") {
+			    "$_" -ne "Owin.dll" -and
+				"$_" -ne "Microsoft.Owin.dll") {
 				$input_dlls = "$input_dlls $output_directory\$_"
 			}
 	}

--- a/source/Core/Configuration/AppBuilderExtensions/UseIdentityServerExtension.cs
+++ b/source/Core/Configuration/AppBuilderExtensions/UseIdentityServerExtension.cs
@@ -81,14 +81,14 @@ namespace Owin
             app.ConfigureRenderLoggedOutPage();
 
             var container = AutofacConfig.Configure(options);
-
-            app.UseCors();
-            app.ConfigureCookieAuthentication(options.AuthenticationOptions.CookieOptions, options.DataProtector);
             app.UseAutofacMiddleware(container);
 
             // this needs to be before external middleware
+            app.UseCors();
+            app.ConfigureCookieAuthentication(options.AuthenticationOptions.CookieOptions, options.DataProtector);            
             app.ConfigureSignOutMessageCookie();
 
+            app.UseMiddlewareFromContainer(container);
 
             if (options.PluginConfiguration != null)
             {

--- a/source/Core/Configuration/AppBuilderExtensions/UseIdentityServerExtension.cs
+++ b/source/Core/Configuration/AppBuilderExtensions/UseIdentityServerExtension.cs
@@ -81,10 +81,10 @@ namespace Owin
             app.ConfigureRenderLoggedOutPage();
 
             var container = AutofacConfig.Configure(options);
-            app.UseAutofacMiddleware(container);
 
             app.UseCors();
             app.ConfigureCookieAuthentication(options.AuthenticationOptions.CookieOptions, options.DataProtector);
+            app.UseAutofacMiddleware(container);
 
             // this needs to be before external middleware
             app.ConfigureSignOutMessageCookie();

--- a/source/Core/Internal/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
+++ b/source/Core/Internal/Autofac.Integration.Owin/AutofacAppBuilderExtensions.cs
@@ -67,9 +67,7 @@ namespace Owin
                     context.Set(Constants.OwinLifetimeScopeKey, lifetimeScope);
                     await next();
                 }
-            });
-
-            UseMiddlewareFromContainer(app, container);
+            });            
 
             // idsvr : remove these guards so that multiple copies of middleware can be registered
             //app.Properties.Add(MiddlewareRegisteredKey, true);
@@ -78,7 +76,7 @@ namespace Owin
         }
 
         [SecuritySafeCritical]
-        static void UseMiddlewareFromContainer(this IAppBuilder app, IComponentContext container)
+        internal static void UseMiddlewareFromContainer(this IAppBuilder app, IComponentContext container)
         {
             var services = container.ComponentRegistry.Registrations.SelectMany(r => r.Services)
                 .OfType<TypedService>()

--- a/source/IdentityServer3.nuspec
+++ b/source/IdentityServer3.nuspec
@@ -19,6 +19,7 @@
     <tags>IdentityServer OpenID Connect OpenIDConnect OAuth2 OWIN ASP.NET Katana WebApi SSO Federation Claims Identity</tags>
     <dependencies>
       <dependency id="Owin" version="1.0"/>
+	  <dependency id="Microsoft.Owin" version="3.0.1"/>
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
We have included a user migration flow on login from an old auth system of ours, this migration flow and other custom pages we require like forgot passwords, forcing a users password to be reset etc have been implemented as owin middelware components and registered with idsrv's autofac container. 

Having these components run after ```app.ConfigureCookieAuthentication(..)``` allows us to retrieve a partially authenticated ClaimsIdentity in our middleware components through ``` context.Environment.GetIdentityServerPartialLoginAsync()```