### PR TITLE
Create an abstract interface for Client Validation

### DIFF
--- a/source/Core/Configuration/Hosting/AutoFacConfig.cs
+++ b/source/Core/Configuration/Hosting/AutoFacConfig.cs
@@ -68,6 +68,7 @@ namespace IdentityServer3.Core.Configuration.Hosting
             builder.RegisterDefaultType<IExternalClaimsFilter, NopClaimsFilter>(fact.ExternalClaimsFilter);
             builder.RegisterDefaultType<ICustomTokenValidator, DefaultCustomTokenValidator>(fact.CustomTokenValidator);
             builder.RegisterDefaultType<IConsentService, DefaultConsentService>(fact.ConsentService);
+            builder.RegisterDefaultType<ICustomClientValidator, DefaultCustomClientValidator>(fact.CustomClientValidator);
 
             // todo remove in next major version
             if (fact.TokenSigningService != null)

--- a/source/Core/Configuration/IdentityServerServiceFactory.cs
+++ b/source/Core/Configuration/IdentityServerServiceFactory.cs
@@ -212,6 +212,14 @@ namespace IdentityServer3.Core.Configuration
         public Registration<ICustomRequestValidator> CustomRequestValidator { get; set; }
 
         /// <summary>
+        /// Gets or sets the custom request validator - Implements custom additional validation of authorize and token requests.
+        /// </summary>
+        /// <value>
+        /// The custom request validator.
+        /// </value>
+        public Registration<ICustomClientValidator> CustomClientValidator { get; set; }
+
+        /// <summary>
         /// Gets or sets the claims provider - Implements retrieval of claims for identity and access tokens.
         /// </summary>
         /// <value>

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -236,8 +236,11 @@
     <Compile Include="Services\Caching\CachingScopeStore.cs" />
     <Compile Include="Services\DefaultViewService\DefaultViewServiceOptions.cs" />
     <Compile Include="Services\DefaultViewService\DefaultViewServiceRegistration.cs" />
+    <Compile Include="Services\Default\DefaultCustomClientValidator.cs" />
+    <Compile Include="Services\Default\DefaultInstanceClientValidator.cs" />
     <Compile Include="Services\Default\DefaultSigningKeyService.cs" />
     <Compile Include="Services\Default\DefaultTokenSigningService.cs" />
+    <Compile Include="Services\ICustomClientValidator.cs" />
     <Compile Include="Services\ISigningKeyService.cs" />
     <Compile Include="Validation\BasicAuthenticationSecretParser.cs" />
     <Compile Include="Validation\IntrospectionRequestValidationResult.cs" />

--- a/source/Core/Services/Default/DefaultCustomClientValidator.cs
+++ b/source/Core/Services/Default/DefaultCustomClientValidator.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IdentityServer3.Core.Validation;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Configuration.Hosting;
+using IdentityServer3.Core.Extensions;
+using IdentityServer3.Core.Logging;
+
+namespace IdentityServer3.Core.Services.Default
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class DefaultCustomClientValidator : ICustomClientValidator
+    {
+        private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
+
+        private readonly IdentityServerOptions _options;
+        private readonly IClientStore _clients;
+        private readonly IRedirectUriValidator _uriValidator;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="options"></param>
+        /// <param name="clients"></param>
+        /// <param name="uriValidator"></param>
+        public DefaultCustomClientValidator(IdentityServerOptions options, IClientStore clients, IRedirectUriValidator uriValidator)
+        {
+            _options = options;
+            _clients = clients;
+            _uriValidator = uriValidator;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public async Task<AuthorizeRequestValidationResult> ValidateAuthorizeRequestAsync(ValidatedAuthorizeRequest request)
+        {
+            //////////////////////////////////////////////////////////
+            // client_id must be present
+            /////////////////////////////////////////////////////////
+            var clientId = request.Raw.Get(Constants.AuthorizeRequest.ClientId);
+            if (clientId.IsMissingOrTooLong(_options.InputLengthRestrictions.ClientId))
+            {
+                LogError("client_id is missing or too long", request);
+                return Invalid(request);
+            }
+
+            request.ClientId = clientId;
+
+
+            //////////////////////////////////////////////////////////
+            // redirect_uri must be present, and a valid uri
+            //////////////////////////////////////////////////////////
+            var redirectUri = request.Raw.Get(Constants.AuthorizeRequest.RedirectUri);
+
+            if (redirectUri.IsMissingOrTooLong(_options.InputLengthRestrictions.RedirectUri))
+            {
+                LogError("redirect_uri is missing or too long", request);
+                return Invalid(request);
+            }
+
+            Uri uri;
+            if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out uri))
+            {
+                LogError("invalid redirect_uri: " + redirectUri, request);
+                return Invalid(request);
+            }
+
+            request.RedirectUri = redirectUri;
+
+
+            //////////////////////////////////////////////////////////
+            // check for valid client
+            //////////////////////////////////////////////////////////
+            var client = await _clients.FindClientByIdAsync(request.ClientId);
+            if (client == null || client.Enabled == false)
+            {
+                LogError("Unknown client or not enabled: " + request.ClientId, request);
+                return Invalid(request, ErrorTypes.User, Constants.AuthorizeErrors.UnauthorizedClient);
+            }
+
+            request.Client = client;
+
+            //////////////////////////////////////////////////////////
+            // check if redirect_uri is valid
+            //////////////////////////////////////////////////////////
+            if (await _uriValidator.IsRedirectUriValidAsync(request.RedirectUri, request.Client) == false)
+            {
+                LogError("Invalid redirect_uri: " + request.RedirectUri, request);
+                return Invalid(request, ErrorTypes.User, Constants.AuthorizeErrors.UnauthorizedClient);
+            }
+
+            return Valid(request);
+        }
+
+        private AuthorizeRequestValidationResult Invalid(ValidatedAuthorizeRequest request, ErrorTypes errorType = ErrorTypes.User, string error = Constants.AuthorizeErrors.InvalidRequest)
+        {
+            var result = new AuthorizeRequestValidationResult
+            {
+                IsError = true,
+                Error = error,
+                ErrorType = errorType,
+                ValidatedRequest = request
+            };
+
+            return result;
+        }
+
+        private AuthorizeRequestValidationResult Valid(ValidatedAuthorizeRequest request)
+        {
+            var result = new AuthorizeRequestValidationResult
+            {
+                IsError = false,
+                ValidatedRequest = request
+            };
+
+            return result;
+        }
+
+        private void LogError(string message, ValidatedAuthorizeRequest request)
+        {
+            var validationLog = new AuthorizeRequestValidationLog(request);
+            var json = LogSerializer.Serialize(validationLog);
+
+            Logger.ErrorFormat("{0}\n {1}", message, json);
+        }
+    }
+}

--- a/source/Core/Services/Default/DefaultInstanceClientValidator.cs
+++ b/source/Core/Services/Default/DefaultInstanceClientValidator.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IdentityServer3.Core.Validation;
+using IdentityServer3.Core.Logging;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Extensions;
+
+namespace IdentityServer3.Core.Services.Default
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class DefaultInstanceClientValidator : ICustomClientValidator
+    {
+        private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
+
+        private readonly IdentityServerOptions _options;
+        private readonly IClientStore _clients;
+        private readonly IRedirectUriValidator _uriValidator;
+        private readonly string _separator = ":";
+
+        public DefaultInstanceClientValidator(IdentityServerOptions options, IClientStore clients, IRedirectUriValidator uriValidator)
+        {
+            _options = options;
+            _clients = clients;
+            _uriValidator = uriValidator;
+        }
+
+        public async Task<AuthorizeRequestValidationResult> ValidateAuthorizeRequestAsync(ValidatedAuthorizeRequest request)
+        {
+            //////////////////////////////////////////////////////////
+            // client_id must be present
+            /////////////////////////////////////////////////////////
+            var clientId = request.Raw.Get(Constants.AuthorizeRequest.ClientId);
+            if (clientId.IsMissingOrTooLong(_options.InputLengthRestrictions.ClientId))
+            {
+                LogError("client_id is missing or too long", request);
+                return Invalid(request);
+            }
+
+            request.ClientId = clientId;
+
+
+            //////////////////////////////////////////////////////////
+            // redirect_uri must be present, and a valid uri
+            //////////////////////////////////////////////////////////
+            var redirectUri = request.Raw.Get(Constants.AuthorizeRequest.RedirectUri);
+
+            if (redirectUri.IsMissingOrTooLong(_options.InputLengthRestrictions.RedirectUri))
+            {
+                LogError("redirect_uri is missing or too long", request);
+                return Invalid(request);
+            }
+
+            Uri uri;
+            if (!Uri.TryCreate(redirectUri, UriKind.Absolute, out uri))
+            {
+                LogError("invalid redirect_uri: " + redirectUri, request);
+                return Invalid(request);
+            }
+
+            request.RedirectUri = redirectUri;
+
+
+            //////////////////////////////////////////////////////////
+            // check for valid client
+            //////////////////////////////////////////////////////////
+            var baseClientId = request.ClientId.Remove(request.ClientId.IndexOf(_separator));
+            var client = await _clients.FindClientByIdAsync(baseClientId);
+            if (client == null || client.Enabled == false)
+            {
+                LogError("Unknown client or not enabled: " + baseClientId, request);
+                return Invalid(request, ErrorTypes.User, Constants.AuthorizeErrors.UnauthorizedClient);
+            }
+
+            request.Client = client;
+
+            //////////////////////////////////////////////////////////
+            // check if redirect_uri is valid
+            //////////////////////////////////////////////////////////
+            if (await _uriValidator.IsRedirectUriValidAsync(request.RedirectUri, request.Client) == false)
+            {
+                LogError("Invalid redirect_uri: " + request.RedirectUri, request);
+                return Invalid(request, ErrorTypes.User, Constants.AuthorizeErrors.UnauthorizedClient);
+            }
+
+            //////////////////////////////////////////////////////////
+            // set Client.ClientId to composite client:instance
+            //////////////////////////////////////////////////////////
+            request.Client.ClientId = request.ClientId;
+            return Valid(request);
+        }
+
+        private AuthorizeRequestValidationResult Invalid(ValidatedAuthorizeRequest request, ErrorTypes errorType = ErrorTypes.User, string error = Constants.AuthorizeErrors.InvalidRequest)
+        {
+            var result = new AuthorizeRequestValidationResult
+            {
+                IsError = true,
+                Error = error,
+                ErrorType = errorType,
+                ValidatedRequest = request
+            };
+
+            return result;
+        }
+
+        private AuthorizeRequestValidationResult Valid(ValidatedAuthorizeRequest request)
+        {
+            var result = new AuthorizeRequestValidationResult
+            {
+                IsError = false,
+                ValidatedRequest = request
+            };
+
+            return result;
+        }
+
+        private void LogError(string message, ValidatedAuthorizeRequest request)
+        {
+            var validationLog = new AuthorizeRequestValidationLog(request);
+            var json = LogSerializer.Serialize(validationLog);
+
+            Logger.ErrorFormat("{0}\n {1}", message, json);
+        }
+    }
+}

--- a/source/Core/Services/ICustomClientValidator.cs
+++ b/source/Core/Services/ICustomClientValidator.cs
@@ -1,0 +1,23 @@
+﻿using IdentityServer3.Core.Validation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IdentityServer3.Core.Services
+{
+    /// <summary>
+    /// Allows inserting custom client validation logic into authorize requests
+    /// </summary>
+    public interface ICustomClientValidator
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        Task<AuthorizeRequestValidationResult> ValidateAuthorizeRequestAsync(ValidatedAuthorizeRequest request);
+
+    }
+}

--- a/source/Tests/UnitTests/Core.Tests.csproj
+++ b/source/Tests/UnitTests/Core.Tests.csproj
@@ -186,6 +186,11 @@
     <Compile Include="Services\Default\DefaultLocalizationServiceTests.cs" />
     <Compile Include="TestCert.cs" />
     <Compile Include="TestExtensions.cs" />
+    <Compile Include="Validation\AuthorizeRequest Validation\Authorize_ClientInstanceValidation_Code.cs" />
+    <Compile Include="Validation\AuthorizeRequest Validation\Authorize_ClientInstanceValidation_IdToken.cs" />
+    <Compile Include="Validation\AuthorizeRequest Validation\Authorize_ClientInstanceValidation_Token.cs" />
+    <Compile Include="Validation\AuthorizeRequest Validation\Authorize_ClientInstanceValidation_Valid.cs" />
+    <Compile Include="Validation\AuthorizeRequest Validation\Authorize_ClientValidation_Instance.cs" />
     <Compile Include="Validation\BearerTokenUsageValidation.cs" />
     <Compile Include="Validation\CustomGrantValidation.cs" />
     <Compile Include="Validation\Secrets\BasicAuthenticationCredentialParsing.cs" />

--- a/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_Code.cs
+++ b/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_Code.cs
@@ -1,0 +1,154 @@
+﻿using FluentAssertions;
+using IdentityServer3.Core;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Services.Default;
+using IdentityServer3.Core.Validation;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer3.Tests.Validation.AuthorizeRequest_Validation
+{
+    public class Authorize_ClientInstanceValidation_Code
+    {
+        IdentityServerOptions _options = TestIdentityServerOptions.Create();
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Code")]
+        public async Task Code_Request_Unknown_Scope()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "unknown");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options, 
+                    Factory.CreateClientStore(), 
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.Client);
+            result.Error.Should().Be(Constants.AuthorizeErrors.InvalidScope);
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Code")]
+        public async Task OpenId_Code_Request_Invalid_RedirectUri()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://invalid");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.User);
+            result.Error.Should().Be(Constants.AuthorizeErrors.UnauthorizedClient);
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Code")]
+        public async Task OpenId_Code_Request_Invalid_IdToken_ResponseType()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.IdToken);
+            parameters.Add(Constants.AuthorizeRequest.Nonce, "abc");
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.User);
+            result.Error.Should().Be(Constants.AuthorizeErrors.UnauthorizedClient);
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Code")]
+        public async Task OpenId_Code_Request_Invalid_IdTokenToken_ResponseType()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.IdTokenToken);
+            parameters.Add(Constants.AuthorizeRequest.Nonce, "abc");
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.User);
+            result.Error.Should().Be(Constants.AuthorizeErrors.UnauthorizedClient);
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Code")]
+        public async Task OpenId_Code_Request_With_Unknown_Client()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "unknown:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.User);
+            result.Error.Should().Be(Constants.AuthorizeErrors.UnauthorizedClient);
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Code")]
+        public async Task OpenId_Code_Request_With_Restricted_Scope()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient_restricted:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid profile");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.User);
+            result.Error.Should().Be(Constants.AuthorizeErrors.UnauthorizedClient);
+        }
+    }
+}

--- a/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_IdToken.cs
+++ b/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_IdToken.cs
@@ -1,0 +1,43 @@
+﻿using FluentAssertions;
+using IdentityServer3.Core;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Services.Default;
+using IdentityServer3.Core.Validation;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer3.Tests.Validation.AuthorizeRequest_Validation
+{
+    public class Authorize_ClientInstanceValidation_IdToken
+    {
+        IdentityServerOptions _options = TestIdentityServerOptions.Create();
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - IdToken")]
+        public async Task Mixed_IdToken_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "implicitclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "oob://implicit/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.IdToken);
+            parameters.Add(Constants.AuthorizeRequest.Nonce, "abc");
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.Client);
+            result.Error.Should().Be(Constants.AuthorizeErrors.InvalidScope);
+        }
+    }
+}

--- a/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_Token.cs
+++ b/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_Token.cs
@@ -1,0 +1,42 @@
+﻿using FluentAssertions;
+using IdentityServer3.Core;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Services.Default;
+using IdentityServer3.Core.Validation;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer3.Tests.Validation.AuthorizeRequest_Validation
+{
+    public class Authorize_ClientInstanceValidation_Token
+    {
+        IdentityServerOptions _options = TestIdentityServerOptions.Create();
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Token")]
+        public async Task Mixed_Token_Request_Without_OpenId_Scope()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "implicitclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "resource profile");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "oob://implicit/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Token);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.Client);
+            result.Error.Should().Be(Constants.AuthorizeErrors.InvalidScope);
+        }
+    }
+}

--- a/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_Valid.cs
+++ b/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientInstanceValidation_Valid.cs
@@ -1,0 +1,182 @@
+﻿using FluentAssertions;
+using IdentityServer3.Core;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Services.Default;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer3.Tests.Validation.AuthorizeRequest_Validation
+{
+    public class Authorize_ClientInstanceValidation_Valid
+    {
+        IdentityServerOptions _options = TestIdentityServerOptions.Create();
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_OpenId_Code_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_Resource_Code_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_Mixed_Code_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_Mixed_Code_Request_Multiple_Scopes()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "codeclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid profile resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "https://server/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Code);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_OpenId_IdTokenToken_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "implicitclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "oob://implicit/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.IdTokenToken);
+            parameters.Add(Constants.AuthorizeRequest.Nonce, "abc");
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_Mixed_IdTokenToken_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "implicitclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "oob://implicit/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.IdTokenToken);
+            parameters.Add(Constants.AuthorizeRequest.Nonce, "abc");
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_Mixed_IdTokenToken_Request_Multiple_Scopes()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "implicitclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid profile resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "oob://implicit/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.IdTokenToken);
+            parameters.Add(Constants.AuthorizeRequest.Nonce, "abc");
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - Valid")]
+        public async Task Valid_Resource_Token_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "implicitclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "oob://implicit/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.Token);
+
+            var validator = Factory.CreateAuthorizeRequestValidator(clientValidator: new DefaultInstanceClientValidator(
+                    _options,
+                    Factory.CreateClientStore(),
+                    new DefaultRedirectUriValidator()
+                ));
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeFalse();
+        }
+    }
+}

--- a/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Instance.cs
+++ b/source/Tests/UnitTests/Validation/AuthorizeRequest Validation/Authorize_ClientValidation_Instance.cs
@@ -1,0 +1,38 @@
+﻿using FluentAssertions;
+using IdentityServer3.Core;
+using IdentityServer3.Core.Configuration;
+using IdentityServer3.Core.Validation;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace IdentityServer3.Tests.Validation.AuthorizeRequest_Validation
+{
+    public class Authorize_ClientValidation_Instance
+    {
+        IdentityServerOptions _options = TestIdentityServerOptions.Create();
+
+        [Fact]
+        [Trait("Category", "AuthorizeRequest Client Validation - IdToken")]
+        public async Task Mixed_IdToken_Request()
+        {
+            var parameters = new NameValueCollection();
+            parameters.Add(Constants.AuthorizeRequest.ClientId, "implicitclient:instance");
+            parameters.Add(Constants.AuthorizeRequest.Scope, "openid resource");
+            parameters.Add(Constants.AuthorizeRequest.RedirectUri, "oob://implicit/cb");
+            parameters.Add(Constants.AuthorizeRequest.ResponseType, Constants.ResponseTypes.IdToken);
+            parameters.Add(Constants.AuthorizeRequest.Nonce, "abc");
+
+            var validator = Factory.CreateAuthorizeRequestValidator();
+            var result = await validator.ValidateAsync(parameters);
+
+            result.IsError.Should().BeTrue();
+            result.ErrorType.Should().Be(ErrorTypes.User);
+            result.Error.Should().Be(Constants.AuthorizeErrors.UnauthorizedClient);
+        }
+    }
+}

--- a/source/Tests/UnitTests/Validation/Setup/Factory.cs
+++ b/source/Tests/UnitTests/Validation/Setup/Factory.cs
@@ -125,6 +125,7 @@ namespace IdentityServer3.Tests.Validation
             IClientStore clients = null,
             IUserService users = null,
             ICustomRequestValidator customValidator = null,
+            ICustomClientValidator clientValidator = null,
             IRedirectUriValidator uriValidator = null,
             ScopeValidator scopeValidator = null,
             IDictionary<string, object> environment = null)
@@ -154,6 +155,11 @@ namespace IdentityServer3.Tests.Validation
                 uriValidator = new DefaultRedirectUriValidator();
             }
 
+            if (clientValidator == null)
+            {
+                clientValidator = new DefaultCustomClientValidator(options, clients, uriValidator);
+            }
+
             if (scopeValidator == null)
             {
                 scopeValidator = new ScopeValidator(scopes);
@@ -163,7 +169,7 @@ namespace IdentityServer3.Tests.Validation
             mockSessionCookie.CallBase = false;
             mockSessionCookie.Setup(x => x.GetSessionId()).Returns((string)null);
 
-            return new AuthorizeRequestValidator(options, clients, customValidator, uriValidator, scopeValidator, mockSessionCookie.Object);
+            return new AuthorizeRequestValidator(options, clients, customValidator, clientValidator, uriValidator, scopeValidator, mockSessionCookie.Object);
 
         }
 


### PR DESCRIPTION
I desired a way to force individual client instances (e.g. Chrome browsers on multiple computers but being used by one user) to be able to force consent for each individual device. Since the client device is a combination of the software client and the device, modifying how clients were validated to add an "instance" identifier seemed to make the most sense. Therefore, the following changes were made:

- Converted ValidateClientAsync in AuthorizeRequstValidator to an
ICustomClientValidator with the appropriate changes to the constructor.
- Added two Validators, a default one and one that supports client identifiers in the form of client:instance, where instance should be
unique.
- Added unit testing.
- Modified Autofac to register a default.
- Modified IdentityServerServiceFactory to add the registration.