### PR TITLE
endSessionController: dont add null clients to the client list

### DIFF
--- a/source/Core/Endpoints/Connect/EndSessionController.cs
+++ b/source/Core/Endpoints/Connect/EndSessionController.cs
@@ -182,7 +182,12 @@ namespace IdentityServer3.Core.Endpoints
             var clients = new List<Client>();
             foreach (var clientId in clientIds)
             {
-                clients.Add(await _clientStore.FindClientByIdAsync(clientId));
+                var client = await _clientStore.FindClientByIdAsync(clientId);
+
+                if (client != null)
+                {
+                    clients.Add(client);
+                }
             }
 
             // get user's session id. session id will possibly 


### PR DESCRIPTION
* Define two clients, "firstaccess" and "secondaccess".
* Perform a loginwith both (their ids get written to the `idsvr.clients` clients cookie)
* Remove one of the clients (I removed secondaccess).
* Logout for the token of the first client now fails with the following :
  ```
  System.NullReferenceException: Object reference not set to an instance of an object.
     at IdentityServer3.Core.Endpoints.EndSessionController.<GetClientEndSessionUrlsAsync>d__11.MoveNext() in c:\local\identity\server3\Core\source\Core\Endpoints\Connect\EndSessionController.cs:line 195
  ```

This is due to `_clientStore.FindClientByIdAsync(clientId)` being able to return null if it cannot find a client by id.