### PR TITLE
Add Kentor SAML2 Middleware to example config

### DIFF
--- a/source/Host.Configuration/Host.Configuration.csproj
+++ b/source/Host.Configuration/Host.Configuration.csproj
@@ -35,6 +35,14 @@
       <HintPath>..\packages\IdentityModel.1.3.1\lib\net45\IdentityModel.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Kentor.AuthServices, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Kentor.AuthServices.0.17.0\lib\net45\Kentor.AuthServices.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Kentor.AuthServices.Owin, Version=0.17.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Kentor.AuthServices.Owin.0.17.0\lib\net45\Kentor.AuthServices.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.2.33, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.2.206221351\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
       <Private>True</Private>

--- a/source/Host.Configuration/IdentityServerExtension.cs
+++ b/source/Host.Configuration/IdentityServerExtension.cs
@@ -17,12 +17,17 @@
 using Host.Configuration;
 using IdentityServer3.Core.Configuration;
 using IdentityServer3.Host.Config;
+using Kentor.AuthServices;
+using Kentor.AuthServices.Configuration;
+using Kentor.AuthServices.Owin;
 using Microsoft.Owin;
 using Microsoft.Owin.Security.Facebook;
 using Microsoft.Owin.Security.Google;
 using Microsoft.Owin.Security.OpenIdConnect;
 using Microsoft.Owin.Security.Twitter;
 using Microsoft.Owin.Security.WsFederation;
+using System.IdentityModel.Metadata;
+using System.IdentityModel.Selectors;
 
 namespace Owin
 {
@@ -156,6 +161,28 @@ namespace Owin
                 Wtrealm = "urn:idsrv3"
             };
             app.UseWsFederationAuthentication(was);
+
+            var saml2 = new KentorAuthServicesAuthenticationOptions(false)
+            {
+                AuthenticationType = "saml2",
+                Caption = "SAML2",
+                SignInAsAuthenticationType = signInAsType,
+                SPOptions = new SPOptions
+                {
+                    EntityId = new EntityId("https://localhost:44333/core/AuthServices"),
+                },
+            };
+
+            saml2.SPOptions.ServiceCertificates.Add(Cert.Load());
+
+            saml2.IdentityProviders.Add(new IdentityProvider(
+                new EntityId("http://stubidp.kentor.se/Metadata"),
+                saml2.SPOptions)
+            {
+                LoadMetadata = true
+            });
+
+            app.UseKentorAuthServicesAuthentication(saml2);
         }
     }
 }

--- a/source/Host.Configuration/packages.config
+++ b/source/Host.Configuration/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="IdentityModel" version="1.3.1" targetFramework="net452" />
+  <package id="Kentor.AuthServices" version="0.17.0" targetFramework="net452" />
+  <package id="Kentor.AuthServices.Owin" version="0.17.0" targetFramework="net452" />
   <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
   <package id="Microsoft.Owin.Security" version="3.0.1" targetFramework="net45" />


### PR DESCRIPTION
- Configured to use the public stubidp.kentor.se test IDP.
