### PR TITLE
Restore refresh token subject

### DIFF
--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -617,6 +617,7 @@ namespace IdentityServer3.Core.Validation
                 return Invalid(Constants.TokenErrors.InvalidRequest);
             }
 
+            _validatedRequest.Subject = principal;
             Logger.Info("Validation of refresh token request success");
             return Valid();
         }


### PR DESCRIPTION
I've faced with issue, when I use IdentityServer3.MongoDb together with setting `Client.UpdateAccessTokenClaimsOnRefresh=true`
Implementation of RefreshTokenStore for MongoDB doesn't store field RefreshToken.Subject, but store SubjectId & AccessToken with its claims. So the Source field is not restored from DB. Later code checks if a RefreshToken has Source field and only in this case performs call to UserService.GetProfileData to update claims.

Curent workaround is adding custom RequestValidator to re-create refresh token's subject. 