### PR TITLE
Use JsonWebKey instead of certificate in ISigningKeyService

### DIFF
--- a/source/Core/Configuration/Hosting/AutoFacConfig.cs
+++ b/source/Core/Configuration/Hosting/AutoFacConfig.cs
@@ -78,9 +78,10 @@ namespace IdentityServer3.Core.Configuration.Hosting
             }
             else
             {
-                builder.Register(new Registration<ITokenSigningService>(r => new DefaultTokenSigningService(r.Resolve<ISigningKeyService>())));
+                builder.Register(new Registration<ITokenSigningService>(r => new DefaultTokenSigningService(r.Resolve<ISigningKeyService>(), r.Resolve<ICertificateSigningKeyService>())));
             }
 
+            builder.RegisterDefaultType<ICertificateSigningKeyService, DefaultSigningKeyService>(fact.CertificateSigningKeyService);
             builder.RegisterDefaultType<ISigningKeyService, DefaultSigningKeyService>(fact.SigningKeyService);
             builder.RegisterDecoratorDefaultType<IEventService, EventServiceDecorator, DefaultEventService>(fact.EventService);
 

--- a/source/Core/Configuration/IdentityServerServiceFactory.cs
+++ b/source/Core/Configuration/IdentityServerServiceFactory.cs
@@ -331,6 +331,14 @@ namespace IdentityServer3.Core.Configuration
         /// </value>
         public Registration<ISigningKeyService> SigningKeyService { get; set; }
 
+        /// <summary>
+        /// Gets or sets the certificate key service.
+        /// </summary>
+        /// <value>
+        /// The signing key service.
+        /// </value>
+        public Registration<ICertificateSigningKeyService> CertificateSigningKeyService { get; set; }
+
         internal void Validate()
         {
             if (UserService == null) LogAndStop("UserService not configured");

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -55,11 +55,19 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Autofac.WebApi2.3.4.0\lib\net45\Autofac.Integration.WebApi.dll</HintPath>
     </Reference>
+    <Reference Include="BouncyCastle.Crypto, Version=1.7.4137.9688, Culture=neutral, PublicKeyToken=a4292a325f69b123, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.1.7.0\lib\Net40-Client\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="IdentityModel.Net45, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\IdentityModel.1.3.1\lib\net45\IdentityModel.Net45.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.2.33, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.2.206221351\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
@@ -240,7 +248,9 @@
     <Compile Include="Services\Default\DefaultCustomTokenResponseGenerator.cs" />
     <Compile Include="Services\Default\DefaultSigningKeyService.cs" />
     <Compile Include="Services\Default\DefaultTokenSigningService.cs" />
+    <Compile Include="Services\Default\X509CertificateFactory.cs" />
     <Compile Include="Services\IAuthenticationSessionValidator.cs" />
+    <Compile Include="Services\ICertificateSigningKeyService.cs" />
     <Compile Include="Services\ICustomTokenResponseGenerator.cs" />
     <Compile Include="Services\ISigningKeyService.cs" />
     <Compile Include="Validation\BasicAuthenticationSecretParser.cs" />

--- a/source/Core/Endpoints/Connect/DiscoveryEndpointController.cs
+++ b/source/Core/Endpoints/Connect/DiscoveryEndpointController.cs
@@ -239,22 +239,15 @@ namespace IdentityServer3.Core.Endpoints
             {
                 if (pubKey != null)
                 {
-                    var cert64 = Convert.ToBase64String(pubKey.RawData);
-                    var thumbprint = Base64Url.Encode(pubKey.GetCertHash());
-                    var key = pubKey.PublicKey.Key as RSACryptoServiceProvider;
-                    var parameters = key.ExportParameters(false);
-                    var exponent = Base64Url.Encode(parameters.Exponent);
-                    var modulus = Base64Url.Encode(parameters.Modulus);
-
                     var webKey = new JsonWebKeyDto
                     {
-                        kty = "RSA",
-                        use = "sig",
-                        kid = await _keyService.GetKidAsync(pubKey),
-                        x5t = thumbprint,
-                        e = exponent,
-                        n = modulus,
-                        x5c = new[] { cert64 }
+                        kty = pubKey.Kty,
+                        use = pubKey.Use,
+                        kid = pubKey.Kid,
+                        x5t = pubKey.X5t,
+                        e = pubKey.E,
+                        n = pubKey.N,
+                        x5c = pubKey.X5c.ToArray()
                     };
 
                     webKeys.Add(webKey);

--- a/source/Core/Services/Default/DefaultSigningKeyService.cs
+++ b/source/Core/Services/Default/DefaultSigningKeyService.cs
@@ -1,15 +1,19 @@
-﻿using IdentityModel;
-using IdentityServer3.Core.Configuration;
+﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using IdentityModel;
+using IdentityServer3.Core.Configuration;
+using Microsoft.IdentityModel.Protocols;
 
 namespace IdentityServer3.Core.Services.Default
 {
     /// <summary>
     /// Default signing key service based on IdentityServerOptions
     /// </summary>
-    public class DefaultSigningKeyService : ISigningKeyService
+    public class DefaultSigningKeyService : ISigningKeyService, ICertificateSigningKeyService
     {
         private readonly IdentityServerOptions _options;
 
@@ -36,18 +40,55 @@ namespace IdentityServer3.Core.Services.Default
         /// Retrieves all public keys that can be used to validate tokens
         /// </summary>
         /// <returns>x509 certificates</returns>
-        public Task<IEnumerable<X509Certificate2>> GetPublicKeysAsync()
+        public Task<IEnumerable<JsonWebKey>> GetPublicKeysAsync()
         {
-            return Task.FromResult(_options.PublicKeysForMetadata);
+            return Task.FromResult(_options.PublicKeysForMetadata.Select(ToJsonWebKey));
         }
 
         /// <summary>
         /// Retrieves the primary signing key
         /// </summary>
         /// <returns>x509 certificate</returns>
-        public Task<X509Certificate2> GetSigningKeyAsync()
+        public Task<JsonWebKey> GetSigningKeyAsync()
         {
-            return Task.FromResult(_options.SigningCertificate);
+            return Task.FromResult(ToJsonWebKey(_options.SigningCertificate));
+        }
+
+        public Task<X509Certificate2> GetCertificate(JsonWebKey key)
+        {
+            if (Base64Url.Encode(_options.SigningCertificate.GetCertHash()).Equals(key.Kid))
+            {
+                return Task.FromResult(_options.SigningCertificate);
+            }
+
+            var cert =
+                _options.PublicKeysForMetadata.FirstOrDefault(
+                    publicCert => Base64Url.Encode(publicCert.GetCertHash()).Equals(key.Kid));
+            return Task.FromResult(cert);
+        }
+
+        private JsonWebKey ToJsonWebKey(X509Certificate2 certificate)
+        {
+            var cert64 = Convert.ToBase64String(certificate.RawData);
+            var thumbprint = Base64Url.Encode(certificate.GetCertHash());
+            var key = certificate.PublicKey.Key as RSACryptoServiceProvider;
+            var parameters = key.ExportParameters(false);
+            var exponent = Base64Url.Encode(parameters.Exponent);
+            var modulus = Base64Url.Encode(parameters.Modulus);
+
+            var jsonWebKey = new JsonWebKey
+            {
+                Kty = "RSA",
+                Use = "sig",
+                Kid = Base64Url.Encode(certificate.GetCertHash()),
+                X5t = thumbprint,
+                E = exponent,
+                N = modulus
+            };
+
+            jsonWebKey.X5c.Add(cert64);
+
+            return jsonWebKey;
         }
     }
 }

--- a/source/Core/Services/Default/X509CertificateFactory.cs
+++ b/source/Core/Services/Default/X509CertificateFactory.cs
@@ -1,0 +1,83 @@
+﻿/*
+ * Copyright 2014, 2015 Dominick Baier, Brock Allen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using Org.BouncyCastle.Asn1.X509;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Prng;
+using Org.BouncyCastle.Math;
+using Org.BouncyCastle.Security;
+using Org.BouncyCastle.X509;
+
+namespace IdentityServer3.Core.Services.Default
+{
+    internal class X509CertificateFactory
+    {
+        internal static X509Certificate2
+            GenerateCertificate(string subjectName, AsymmetricKeyParameter publicKey)
+        {
+            var kpgen = new RsaKeyPairGenerator();
+
+            // certificate strength 1024 bits
+            kpgen.Init(new KeyGenerationParameters(
+                  new SecureRandom(new CryptoApiRandomGenerator()), 1024));
+
+            var gen = new X509V3CertificateGenerator();
+
+            var certName = new X509Name("CN=" + subjectName);
+            var serialNo = BigInteger.ProbablePrime(120, new Random());
+
+            gen.SetSerialNumber(serialNo);
+            gen.SetSubjectDN(certName);
+            gen.SetIssuerDN(certName);
+            gen.SetNotAfter(DateTime.Now.AddYears(100));
+            gen.SetNotBefore(DateTime.Now.Subtract(new TimeSpan(7, 0, 0, 0)));
+            gen.SetSignatureAlgorithm("SHA1withRSA");
+            gen.SetPublicKey(publicKey);
+
+            gen.AddExtension(
+                X509Extensions.AuthorityKeyIdentifier.Id,
+                false,
+                new AuthorityKeyIdentifier(
+                    SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(publicKey),
+                    new GeneralNames(new GeneralName(certName)),
+                    serialNo));
+
+            /* 
+         1.3.6.1.5.5.7.3.1 - id_kp_serverAuth 
+         1.3.6.1.5.5.7.3.2 - id_kp_clientAuth 
+         1.3.6.1.5.5.7.3.3 - id_kp_codeSigning 
+         1.3.6.1.5.5.7.3.4 - id_kp_emailProtection 
+         1.3.6.1.5.5.7.3.5 - id-kp-ipsecEndSystem 
+         1.3.6.1.5.5.7.3.6 - id-kp-ipsecTunnel 
+         1.3.6.1.5.5.7.3.7 - id-kp-ipsecUser 
+         1.3.6.1.5.5.7.3.8 - id_kp_timeStamping 
+         1.3.6.1.5.5.7.3.9 - OCSPSigning
+         */
+            gen.AddExtension(
+                X509Extensions.ExtendedKeyUsage.Id,
+                false,
+                new ExtendedKeyUsage(new[] { KeyPurposeID.IdKPServerAuth }));
+
+
+            var newCert = gen.Generate(kpgen.GenerateKeyPair().Private);
+
+            return new X509Certificate2(newCert.GetEncoded());
+        }
+    }
+}

--- a/source/Core/Services/ICertificateSigningKeyService.cs
+++ b/source/Core/Services/ICertificateSigningKeyService.cs
@@ -1,0 +1,18 @@
+﻿using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+
+namespace IdentityServer3.Core.Services
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface ICertificateSigningKeyService
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        Task<X509Certificate2> GetCertificate(JsonWebKey key);
+    }
+}

--- a/source/Core/Services/ISigningKeyService.cs
+++ b/source/Core/Services/ISigningKeyService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
 
 namespace IdentityServer3.Core.Services
 {
@@ -13,19 +13,12 @@ namespace IdentityServer3.Core.Services
         /// Retrieves the primary signing key
         /// </summary>
         /// <returns>Signing key</returns>
-        Task<X509Certificate2> GetSigningKeyAsync();
+        Task<JsonWebKey> GetSigningKeyAsync();
 
         /// <summary>
         /// Retrieves all public keys that can be used to validate tokens
         /// </summary>
         /// <returns>Public keys</returns>
-        Task<IEnumerable<X509Certificate2>> GetPublicKeysAsync();
-
-        /// <summary>
-        /// Calculates the key id for a given x509 certificate
-        /// </summary>
-        /// <param name="certificate"></param>
-        /// <returns></returns>
-        Task<string> GetKidAsync(X509Certificate2 certificate);
+        Task<IEnumerable<JsonWebKey>> GetPublicKeysAsync();
     }
 }

--- a/source/Core/packages.config
+++ b/source/Core/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net45" />
+  <package id="BouncyCastle" version="1.7.0" targetFramework="net452" />
   <package id="IdentityModel" version="1.3.1" targetFramework="net452" />
   <package id="ILMerge" version="2.14.1208" targetFramework="net45" />
   <package id="LibLog" version="4.2.4" targetFramework="net452" developmentDependency="true" />
@@ -10,6 +11,7 @@
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Tracing" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.IdentityModel.Protocol.Extensions" version="1.0.2.206221351" targetFramework="net452" />
   <package id="Microsoft.Owin" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.Cors" version="3.0.1" targetFramework="net45" />
   <package id="Microsoft.Owin.FileSystems" version="3.0.1" targetFramework="net45" />

--- a/source/Tests/UnitTests/Endpoints/Connect/AccessTokenValidationControllerTests.cs
+++ b/source/Tests/UnitTests/Endpoints/Connect/AccessTokenValidationControllerTests.cs
@@ -191,7 +191,7 @@ namespace IdentityServer3.Tests.Endpoints.Connect
         private class AlwaysValidAccessTokenValidator : TokenValidator
         {
             public AlwaysValidAccessTokenValidator(IdentityServerOptions options, IClientStore clients, ITokenHandleStore tokenHandles, ICustomTokenValidator customValidator, OwinEnvironmentService context)
-                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options))
+                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options), new DefaultSigningKeyService(options))
             {
             }
 
@@ -214,7 +214,7 @@ namespace IdentityServer3.Tests.Endpoints.Connect
         private class AlwaysInvalidAccessTokenValidator : TokenValidator
         {
             public AlwaysInvalidAccessTokenValidator(IdentityServerOptions options, IClientStore clients, ITokenHandleStore tokenHandles, ICustomTokenValidator customValidator, OwinEnvironmentService context)
-                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options))
+                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options), new DefaultSigningKeyService(options))
             {
             }
 

--- a/source/Tests/UnitTests/Endpoints/Connect/IdentityTokenValidationControllerTests.cs
+++ b/source/Tests/UnitTests/Endpoints/Connect/IdentityTokenValidationControllerTests.cs
@@ -219,7 +219,7 @@ namespace IdentityServer3.Tests.Connect.Endpoints
         private class AlwaysValidIdentityTokenValidator : TokenValidator
         {
             public AlwaysValidIdentityTokenValidator(IdentityServerOptions options, IClientStore clients, ITokenHandleStore tokenHandles, ICustomTokenValidator customValidator, OwinEnvironmentService context)
-                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options))
+                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options), new DefaultSigningKeyService(options))
             {
             }
 
@@ -242,7 +242,7 @@ namespace IdentityServer3.Tests.Connect.Endpoints
         private class AlwaysInvalidIdentityTokenValidator : TokenValidator
         {
             public AlwaysInvalidIdentityTokenValidator(IdentityServerOptions options, IClientStore clients, ITokenHandleStore tokenHandles, ICustomTokenValidator customValidator, OwinEnvironmentService context)
-                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options))
+                : base(options, clients, tokenHandles, customValidator, context, new DefaultSigningKeyService(options), new DefaultSigningKeyService(options))
             {
             }
 

--- a/source/Tests/UnitTests/Validation/Setup/Factory.cs
+++ b/source/Tests/UnitTests/Validation/Setup/Factory.cs
@@ -36,7 +36,8 @@ namespace IdentityServer3.Tests.Validation
 
         public static DefaultTokenSigningService CreateDefaultTokenSigningService()
         {
-            return new DefaultTokenSigningService(new DefaultSigningKeyService(TestIdentityServerOptions.Create()));
+            var defaultSigningKeyService = new DefaultSigningKeyService(TestIdentityServerOptions.Create());
+            return new DefaultTokenSigningService(defaultSigningKeyService, defaultSigningKeyService);
         }
 
         //public static ClientValidator CreateClientValidator(
@@ -179,6 +180,7 @@ namespace IdentityServer3.Tests.Validation
             options.Factory = new IdentityServerServiceFactory();
             var context = CreateOwinContext(options, clients, users);
 
+            var defaultSigningKeyService = new DefaultSigningKeyService(options);
             var validator = new TokenValidator(
                 options: options,
                 clients: clients,
@@ -187,7 +189,8 @@ namespace IdentityServer3.Tests.Validation
                     users: users,
                     clients: clients),
                 owinEnvironment: new OwinEnvironmentService(context),
-                keyService: new DefaultSigningKeyService(options));
+                keyService: defaultSigningKeyService,
+                certificateKeyService: defaultSigningKeyService);
 
             return validator;
         }


### PR DESCRIPTION
Hey
This is just a quick demonstration of the way I think we should solve #2727.
The code is completed, and all the tests are passing except the test that check what types are exposed - I think it failed because the `ISingingKeyService` public method return `JsonWebKey` from `Microsoft.IdentityModel.Protocols` assembly.
I will fix it and add some tests, but I first want to discuss if this is a good approach to fix this issue.
Thanks,
Omer