### PR TITLE
Restore RefreshToken.Subject

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,10 @@
 The easiest ways to contribute is to open an issue and start a discussion. 
 Then we can decided if and how a feature or a change could be implemented and if you should submit a pull requests with code changes.
 
+## General questions around token-based authentication and architecture
+We monitor the `identityserver3` tag on [StackOverflow](https://stackoverflow.com/questions/tagged/?tagnames=identityserver3&sort=newest).
 
-
-## General feedback and discussions?
+## Feedback and issues?
 Please start a discussion on the [core repo issue tracker](https://github.com/IdentityServer/IdentityServer3/issues).
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Please log a new issue in the appropriate GitHub repo:
 
 Due to the security nature of IdentityServer, errors are very vague. Make sure you read and understand how to enable [logging](https://identityserver.github.io/Documentation/docsv2/configuration/logging.html) before opening an issue/bug report.
 
-## Other discussions
+## Chat with us and other identityserver users
 https://gitter.im/IdentityServer/IdentityServer3
 
 ## Filing issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ Please log a new issue in the appropriate GitHub repo:
 * [AccessToken validation](https://github.com/IdentityServer/IdentityServer3.AccessTokenValidation)
 * [Samples](https://github.com/IdentityServer/IdentityServer3.Samples)
 
+Due to the security nature of IdentityServer, errors are very vague. Make sure you read and understand how to enable [logging](https://identityserver.github.io/Documentation/docsv2/configuration/logging.html) before opening an issue/bug report.
+
 ## Other discussions
 https://gitter.im/IdentityServer/IdentityServer3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,12 +3,11 @@
 The easiest ways to contribute is to open an issue and start a discussion. 
 Then we can decided if and how a feature or a change could be implemented and if you should submit a pull requests with code changes.
 
-## General questions around token-based authentication and architecture
+## General questions around token-based authentication and architecture?
 We monitor the `identityserver3` tag on [StackOverflow](https://stackoverflow.com/questions/tagged/?tagnames=identityserver3&sort=newest).
 
 ## Feedback and issues?
 Please start a discussion on the [core repo issue tracker](https://github.com/IdentityServer/IdentityServer3/issues).
-
 
 ## Bugs and feature requests?
 Please log a new issue in the appropriate GitHub repo:

--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,0 +1,2 @@
+**Important** Most problems can be solved by simply looking at the logs. Please make sure you read [this](https://identityserver.github.io/Documentation/docsv2/configuration/logging.html)
+first. Feel free to attach **relevant** parts of the log output in a **formatted** block. thanks.

--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,4 +1,4 @@
-[ ] I read and understood how to enable [logging](https://identityserver.github.io/Documentation/docsv2/configuration/logging.html)
+- [ ] I read and understood how to enable [logging](https://identityserver.github.io/Documentation/docsv2/configuration/logging.html)
 
 ### Question / Issue
 

--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -2,6 +2,8 @@
 
 ### Question / Issue
 
+
+
 ### Relevant parts of the log file
 
 ```

--- a/ISSUE_TEMPLATE
+++ b/ISSUE_TEMPLATE
@@ -1,2 +1,9 @@
-**Important** Most problems can be solved by simply looking at the logs. Please make sure you read [this](https://identityserver.github.io/Documentation/docsv2/configuration/logging.html)
-first. Feel free to attach **relevant** parts of the log output in a **formatted** block. thanks.
+[ ] I read and understood how to enable [logging](https://identityserver.github.io/Documentation/docsv2/configuration/logging.html)
+
+### Question / Issue
+
+### Relevant parts of the log file
+
+```
+<log goes here>
+```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Dev build: [![Build status](https://ci.appveyor.com/api/projects/status/rtaj3nb7
 
 IdentityServer is a .NET/Katana-based framework and hostable component that allows implementing single sign-on and access control for modern web applications and APIs using protocols like OpenID Connect and OAuth2. It supports a wide range of clients like mobile, web, SPAs and desktop applications and is extensible to allow integration in new and existing architectures.
 
-Watch this for the big picture: [Introduction to OpenID Connect, OAuth2 and IdentityServer](https://vimeo.com/113604459).
+Watch this for the big picture: [Introduction to OpenID Connect, OAuth2 and IdentityServer](https://vimeo.com/113604459) - and [An Introduction to IdentityServer](https://vimeo.com/154172925) for a more code-centric talk.
 
 Go to the documentation [site](https://identityserver.github.io/Documentation/).
 

--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -617,6 +617,7 @@ namespace IdentityServer3.Core.Validation
                 return Invalid(Constants.TokenErrors.InvalidRequest);
             }
 
+            _validatedRequest.Subject = principal;
             Logger.Info("Validation of refresh token request success");
             return Valid();
         }


### PR DESCRIPTION
I've faced with issue, when I use IdentityServer3.MongoDb together with setting `Client.UpdateAccessTokenClaimsOnRefresh=true`
Implementation of RefreshTokenStore for MongoDB doesn't store field RefreshToken.Subject, but store SubjectId & AccessToken with its claims. So the Source field is not restored from DB. Later code checks if a RefreshToken has Source field and only in this case performs call to UserService.GetProfileData to update claims.

Current workaround is adding custom RequestValidator to re-create refresh token's subject.
