### PR TITLE
Corrected grammar

### DIFF
--- a/source/Core/Configuration/AppBuilderExtensions/UseIdentityServerExtension.cs
+++ b/source/Core/Configuration/AppBuilderExtensions/UseIdentityServerExtension.cs
@@ -131,7 +131,7 @@ namespace Owin
             }
             if (!cert.HasPrivateKey || !cert.IsPrivateAccessAllowed())
             {
-                Logger.Error("Signing certificate has not private key or private key is not accessible. Make sure the account running your application has access to the private key");
+                Logger.Error("Signing certificate has no private key or the private key is not accessible. Make sure the account running your application has access to the private key");
                 await eventSvc.RaiseCertificatePrivateKeyNotAccessibleEventAsync(cert);
 
                 return;


### PR DESCRIPTION
It may also be worth noting in this error that the issue may be due to the private key being in CNG format (http://blog.davidchristiansen.com/2016/05/521/)