### PR TITLE
Added ShowLoginPageOnErrorResult to PostAuthenticationContext

### DIFF
--- a/source/Core/Endpoints/AuthenticationController.cs
+++ b/source/Core/Endpoints/AuthenticationController.cs
@@ -672,7 +672,7 @@ namespace IdentityServer3.Core.Endpoints
         
         private async Task<IHttpActionResult> SignInAndRedirectAsync(SignInMessage signInMessage, string signInMessageId, AuthenticateResult authResult, bool? rememberMe = null)
         {
-            var postAuthenActionResult = await PostAuthenticateAsync(signInMessage, authResult);
+            var postAuthenActionResult = await PostAuthenticateAsync(signInMessage, signInMessageId, authResult);
             if (postAuthenActionResult != null)
             {
                 if (postAuthenActionResult.Item1 != null)
@@ -705,7 +705,7 @@ namespace IdentityServer3.Core.Endpoints
             return Redirect(redirectUrl);
         }
 
-        private async Task<Tuple<IHttpActionResult, AuthenticateResult>> PostAuthenticateAsync(SignInMessage signInMessage, AuthenticateResult result)
+        private async Task<Tuple<IHttpActionResult, AuthenticateResult>> PostAuthenticateAsync(SignInMessage signInMessage, string signInMessageId, AuthenticateResult result)
         {
             if (result.IsPartialSignIn == false)
             {
@@ -728,7 +728,16 @@ namespace IdentityServer3.Core.Endpoints
                 if (authResult.IsError)
                 {
                     Logger.WarnFormat("user service PostAuthenticateAsync returned an error message: {0}", authResult.ErrorMessage);
-                    return new Tuple<IHttpActionResult, AuthenticateResult>(RenderErrorPage(authResult.ErrorMessage), null);
+                    if (ctx.ShowLoginPageOnErrorResult)
+                    {
+                        Logger.Debug("ShowLoginPageOnErrorResult set to true, showing login page with error");
+                        return new Tuple<IHttpActionResult, AuthenticateResult>(await RenderLoginPage(signInMessage, signInMessageId, authResult.ErrorMessage), null);
+                    }
+                    else
+                    {
+                        Logger.Debug("ShowLoginPageOnErrorResult set to false, showing error page with error");
+                        return new Tuple<IHttpActionResult, AuthenticateResult>(RenderErrorPage(authResult.ErrorMessage), null);
+                    }
                 }
 
                 if (result != authResult)

--- a/source/Core/Models/Contexts/PostAuthenticationContext.cs
+++ b/source/Core/Models/Contexts/PostAuthenticationContext.cs
@@ -36,5 +36,10 @@ namespace IdentityServer3.Core.Models
         /// The authenticate result.
         /// </value>
         public AuthenticateResult AuthenticateResult { get; set; }
+
+        /// <summary>
+        /// Gets or sets if the login page should be used to show the error from the authenticate result (as opposed to the general error page).
+        /// </summary>
+        public bool ShowLoginPageOnErrorResult { get; set; }
     }
 }

--- a/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
+++ b/source/Tests/UnitTests/Endpoints/AuthenticationControllerTests.cs
@@ -713,6 +713,24 @@ namespace IdentityServer3.Tests.Endpoints
         }
 
         [Fact]
+        public void PostToLogin_PostAuthenticateReturnsErrorAndShowLoginPageOnErrorResultIsSet_ShowsLoginPageWithError()
+        {
+            mockUserService
+                .Setup(x => x.PostAuthenticateAsync(It.IsAny<PostAuthenticationContext>()))
+                .Callback<PostAuthenticationContext>(ctx => {
+                    ctx.AuthenticateResult = new AuthenticateResult("SomeError");
+                    ctx.ShowLoginPageOnErrorResult = true;
+                })
+                .Returns(Task.FromResult(0));
+            
+            GetLoginPage();
+            var resp = PostForm(GetLoginUrl(), new LoginCredentials { Username = "alice", Password = "alice" });
+            resp.AssertPage("login");
+            var model = resp.GetModel<LoginViewModel>();
+            model.ErrorMessage.Should().Be("SomeError");
+        }
+
+        [Fact]
         public void PostToLogin_PostAuthenticate_returns_partial_login_and_user_is_not_logged_in()
         {
             mockUserService.Setup(x => x.PostAuthenticateAsync(It.IsAny<PostAuthenticationContext>()))


### PR DESCRIPTION
This PR adds the ability to display the login page rather than the error page when PostAuthenticateAsync returns an error result.

This matches the name and behaviour of the property on PreAuthenticationContext added in https://github.com/IdentityServer/IdentityServer3/commit/6a5673f02268cb29faba0e579fb835d7fffa1494
