### PR TITLE
Fix how audience is built in IssueClientToken.

### DIFF
--- a/source/Core/Extensions/OwinEnvironmentExtensions.cs
+++ b/source/Core/Extensions/OwinEnvironmentExtensions.cs
@@ -714,7 +714,7 @@ namespace IdentityServer3.Core.Extensions
             var token = new Token
             {
                 Issuer = issuerUri,
-                Audience = issuerUri + "/resources",
+                Audience = string.Format(Constants.AccessTokenAudience, issuerUri.EnsureTrailingSlash()),
                 Lifetime = lifetime,
                 Claims = new List<Claim>
                 {


### PR DESCRIPTION
Bring the audience string value generation in IssueClientToken in line
with how it is generated in other places in the code base
(DefaultTokenService, TokenValidator).

#2994