### PR TITLE
Making the Event Details public

### DIFF
--- a/source/Core/Events/Authentication/ClientAuthenticationDetails.cs
+++ b/source/Core/Events/Authentication/ClientAuthenticationDetails.cs
@@ -16,7 +16,7 @@
 
 namespace IdentityServer3.Core.Events
 {
-    class ClientAuthenticationDetails
+    public class ClientAuthenticationDetails
     {
         public string ClientId { get; set; }
         public string ClientType { get; set; }

--- a/source/Core/Events/EndpointDetail.cs
+++ b/source/Core/Events/EndpointDetail.cs
@@ -16,7 +16,7 @@
 
 namespace IdentityServer3.Core.Events
 {
-    class EndpointDetail
+    public class EndpointDetail
     {
         public string EndpointName { get; set; }
     }

--- a/source/Core/Events/IntrospectionEndpointDetail.cs
+++ b/source/Core/Events/IntrospectionEndpointDetail.cs
@@ -16,9 +16,8 @@
 
 namespace IdentityServer3.Core.Events
 {
-    class IntrospectionEndpointDetail
+    public class IntrospectionEndpointDetail : EndpointDetail
     {
-        public string EndpointName { get; set; }
         public string Token { get; set; }
         public string ScopeName { get; set; }
         public string TokenStatus { get; set; }


### PR DESCRIPTION
Making the rest of the Event Details public to be exposed when overriding
EventService
- Currently some of the Details are exposed as public, but not all of them.