### PR TITLE
Added publicid for use in translations

### DIFF
--- a/source/Core/Resources/T4resx.cs
+++ b/source/Core/Resources/T4resx.cs
@@ -19,6 +19,7 @@ namespace IdentityServer3.Core.Resources
 			public const string PreLoginSuccess = "PreLoginSuccess";
 			public const string ResourceOwnerFlowLoginFailure = "ResourceOwnerFlowLoginFailure";
 			public const string ResourceOwnerFlowLoginSuccess = "ResourceOwnerFlowLoginSuccess";
+	        public const string TokenRevoked = "TokenRevoked";
 	}
 	public class MessageIds
 	{

--- a/source/Core/Resources/T4resx.cs
+++ b/source/Core/Resources/T4resx.cs
@@ -19,7 +19,7 @@ namespace IdentityServer3.Core.Resources
 			public const string PreLoginSuccess = "PreLoginSuccess";
 			public const string ResourceOwnerFlowLoginFailure = "ResourceOwnerFlowLoginFailure";
 			public const string ResourceOwnerFlowLoginSuccess = "ResourceOwnerFlowLoginSuccess";
-	        public const string TokenRevoked = "TokenRevoked";
+			public const string TokenRevoked = "TokenRevoked";
 	}
 	public class MessageIds
 	{


### PR DESCRIPTION
Missing public id in 2.5.3 for the new Event resource "TokenRevoked".