### PR TITLE
Claims on token revoked details

### DIFF
--- a/source/Core/Events/Authentication/TokenRevokedDetails.cs
+++ b/source/Core/Events/Authentication/TokenRevokedDetails.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using IdentityServer3.Core.Models;
 
 namespace IdentityServer3.Core.Events
@@ -44,5 +45,14 @@ namespace IdentityServer3.Core.Events
         /// </summary>
         /// <value></value>
         public string SubjectId { get; set; }
+
+
+        /// <summary>
+        /// Gets or sets the claims.
+        /// </summary>
+        /// <value>
+        /// The claims.
+        /// </value>
+        public Dictionary<string, object> Claims { get; set; }
     }
 }

--- a/source/Core/Extensions/IEventServiceExtensions.cs
+++ b/source/Core/Extensions/IEventServiceExtensions.cs
@@ -18,6 +18,7 @@ using IdentityServer3.Core.Events;
 using IdentityServer3.Core.Models;
 using IdentityServer3.Core.Services;
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -26,16 +27,17 @@ namespace IdentityServer3.Core.Extensions
 {
     internal static class IEventServiceExtensions
     {
-        public static async Task RaisePreLoginSuccessEventAsync(this IEventService events, 
+        public static async Task RaisePreLoginSuccessEventAsync(this IEventService events,
             string signInMessageId, SignInMessage signInMessage, AuthenticateResult authResult)
         {
             var evt = new Event<LoginDetails>(
                 EventConstants.Categories.Authentication,
                 Resources.Events.PreLoginSuccess,
-                EventTypes.Success, 
+                EventTypes.Success,
                 EventConstants.Ids.PreLoginSuccess,
-                new LoginDetails {
-                    SubjectId = authResult.HasSubject ?  authResult.User.GetSubjectId() : null,
+                new LoginDetails
+                {
+                    SubjectId = authResult.HasSubject ? authResult.User.GetSubjectId() : null,
                     Name = authResult.User.Identity.Name,
                     SignInId = signInMessageId,
                     SignInMessage = signInMessage,
@@ -45,7 +47,7 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaisePreLoginFailureEventAsync(this IEventService events, 
+        public static async Task RaisePreLoginFailureEventAsync(this IEventService events,
             string signInMessageId, SignInMessage signInMessage, string error)
         {
             var evt = new Event<LoginDetails>(
@@ -57,13 +59,13 @@ namespace IdentityServer3.Core.Extensions
                 {
                     SignInId = signInMessageId,
                     SignInMessage = signInMessage,
-                }, 
+                },
                 error);
 
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseLocalLoginSuccessEventAsync(this IEventService events, 
+        public static async Task RaiseLocalLoginSuccessEventAsync(this IEventService events,
             string username, string signInMessageId, SignInMessage signInMessage, AuthenticateResult authResult)
         {
             var evt = new Event<LocalLoginDetails>(
@@ -84,7 +86,7 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseLocalLoginFailureEventAsync(this IEventService events, 
+        public static async Task RaiseLocalLoginFailureEventAsync(this IEventService events,
             string username, string signInMessageId, SignInMessage signInMessage, string error)
         {
             var evt = new Event<LocalLoginDetails>(
@@ -97,13 +99,13 @@ namespace IdentityServer3.Core.Extensions
                     SignInId = signInMessageId,
                     SignInMessage = signInMessage,
                     LoginUserName = username
-                }, 
+                },
                 error);
 
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseExternalLoginSuccessEventAsync(this IEventService events, 
+        public static async Task RaiseExternalLoginSuccessEventAsync(this IEventService events,
             ExternalIdentity externalIdentity, string signInMessageId, SignInMessage signInMessage, AuthenticateResult authResult)
         {
             var evt = new Event<ExternalLoginDetails>(
@@ -125,7 +127,7 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseExternalLoginFailureEventAsync(this IEventService events, 
+        public static async Task RaiseExternalLoginFailureEventAsync(this IEventService events,
             ExternalIdentity externalIdentity, string signInMessageId, SignInMessage signInMessage, string error)
         {
             var evt = new Event<ExternalLoginDetails>(
@@ -139,7 +141,7 @@ namespace IdentityServer3.Core.Extensions
                     SignInMessage = signInMessage,
                     Provider = externalIdentity.Provider,
                     ProviderId = externalIdentity.ProviderId,
-                }, 
+                },
                 error);
 
             await events.RaiseEventAsync(evt);
@@ -157,7 +159,7 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseSuccessfulResourceOwnerFlowAuthenticationEventAsync(this IEventService events, 
+        public static async Task RaiseSuccessfulResourceOwnerFlowAuthenticationEventAsync(this IEventService events,
             string userName, string subjectId, SignInMessage message)
         {
             var evt = new Event<LocalLoginDetails>(
@@ -175,7 +177,7 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseFailedResourceOwnerFlowAuthenticationEventAsync(this IEventService events, 
+        public static async Task RaiseFailedResourceOwnerFlowAuthenticationEventAsync(this IEventService events,
             string userName, SignInMessage message, string error)
         {
             var evt = new Event<LocalLoginDetails>(
@@ -193,7 +195,7 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaisePartialLoginCompleteEventAsync(this IEventService events, 
+        public static async Task RaisePartialLoginCompleteEventAsync(this IEventService events,
             ClaimsIdentity subject, string signInMessageId, SignInMessage signInMessage)
         {
             var evt = new Event<LoginDetails>(
@@ -212,7 +214,7 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseLogoutEventAsync(this IEventService events, 
+        public static async Task RaiseLogoutEventAsync(this IEventService events,
             ClaimsPrincipal subject, string signOutId, SignOutMessage signOutMessage)
         {
             var evt = new Event<LogoutDetails>(
@@ -239,7 +241,8 @@ namespace IdentityServer3.Core.Extensions
                 EventTypes.Information,
                 EventConstants.Ids.CspReport);
 
-            evt.DetailsFunc = () => {
+            evt.DetailsFunc = () =>
+            {
                 string subject = null;
                 string name = null;
                 if (user != null && user.Identity.IsAuthenticated)
@@ -253,7 +256,7 @@ namespace IdentityServer3.Core.Extensions
                 {
                     reportData = Newtonsoft.Json.JsonConvert.DeserializeObject(report);
                 }
-                catch(Newtonsoft.Json.JsonReaderException)
+                catch (Newtonsoft.Json.JsonReaderException)
                 {
                     reportData = "Error reading CSP report JSON";
                     evt.Message = "Raw Report Data: " + report;
@@ -406,7 +409,9 @@ namespace IdentityServer3.Core.Extensions
             await events.RaiseEventAsync(evt);
         }
 
-        public static async Task RaiseTokenRevokedEventAsync(this IEventService events, string subjectId, string token, string tokenType)
+        public static async Task RaiseTokenRevokedEventAsync(this IEventService events,
+            List<Claim> claims,
+            string subjectId, string handle, string tokenType)
         {
             var evt = new Event<TokenRevokedDetails>(
                 EventConstants.Categories.Authentication,
@@ -416,8 +421,9 @@ namespace IdentityServer3.Core.Extensions
                 new TokenRevokedDetails()
                 {
                     SubjectId = subjectId,
-                    Token = ObfuscateToken(token),
-                    TokenType = tokenType
+                    Token = ObfuscateToken(handle),
+                    TokenType = tokenType,
+                    Claims = claims.ToClaimsDictionary()
                 });
 
             await events.RaiseEventAsync(evt);
@@ -429,7 +435,7 @@ namespace IdentityServer3.Core.Extensions
                 EventConstants.Categories.InternalError,
                 "Unhandled exception",
                 EventTypes.Error,
-                EventConstants.Ids.UnhandledExceptionError, 
+                EventConstants.Ids.UnhandledExceptionError,
                 exception.ToString());
 
             await events.RaiseEventAsync(evt);

--- a/source/Tests/UnitTests/Core.Tests.csproj
+++ b/source/Tests/UnitTests/Core.Tests.csproj
@@ -195,15 +195,6 @@
     <Compile Include="Endpoints\Connect\PoP\PoPAsymmetricTestsCode.cs" />
     <Compile Include="Endpoints\Connect\PoP\RsaPublicKeyJwk.cs" />
     <Compile Include="Endpoints\Setup\MockUserService.cs" />
-<<<<<<< Updated upstream
-=======
-    <Compile Include="Events\TokenRevokedDetailsTests.cs" />
-    <Compile Include="ResponseHandling\TokenErrorResultTests.cs" />
-    <Compile Include="ResponseHandling\TokenExtensionsTests.cs" />
-    <Compile Include="ResponseHandling\TokenResponseGeneratorTests_CustomResponseParameters.cs" />
-    <Compile Include="ResponseHandling\TokenResultTests.cs" />
-    <Compile Include="Events\RefreshTokenRefreshDetailsTests.cs" />
->>>>>>> Stashed changes
     <Compile Include="Services\Default\DefaultCorsPolicyServiceTests.cs" />
     <Compile Include="Services\Default\DefaultLocalizationServiceTests.cs" />
     <Compile Include="TestCert.cs" />

--- a/source/Tests/UnitTests/Core.Tests.csproj
+++ b/source/Tests/UnitTests/Core.Tests.csproj
@@ -195,6 +195,15 @@
     <Compile Include="Endpoints\Connect\PoP\PoPAsymmetricTestsCode.cs" />
     <Compile Include="Endpoints\Connect\PoP\RsaPublicKeyJwk.cs" />
     <Compile Include="Endpoints\Setup\MockUserService.cs" />
+<<<<<<< Updated upstream
+=======
+    <Compile Include="Events\TokenRevokedDetailsTests.cs" />
+    <Compile Include="ResponseHandling\TokenErrorResultTests.cs" />
+    <Compile Include="ResponseHandling\TokenExtensionsTests.cs" />
+    <Compile Include="ResponseHandling\TokenResponseGeneratorTests_CustomResponseParameters.cs" />
+    <Compile Include="ResponseHandling\TokenResultTests.cs" />
+    <Compile Include="Events\RefreshTokenRefreshDetailsTests.cs" />
+>>>>>>> Stashed changes
     <Compile Include="Services\Default\DefaultCorsPolicyServiceTests.cs" />
     <Compile Include="Services\Default\DefaultLocalizationServiceTests.cs" />
     <Compile Include="TestCert.cs" />

--- a/source/Tests/UnitTests/Events/TokenRevokedDetailsTests.cs
+++ b/source/Tests/UnitTests/Events/TokenRevokedDetailsTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using IdentityServer3.Core.Events;
+using IdentityServer3.Core.Extensions;
+using IdentityServer3.Core.Models;
+using IdentityServer3.Core.Services;
+using Moq;
+using Xunit;
+
+namespace IdentityServer3.Tests.Events
+{
+    public class TokenRevokedDetailsTests
+    {
+        [Fact]
+        public async Task When_claims_are_provided_then_create_event_with_given_claims()
+        {
+            // Given
+            var handle = "handle";
+            var subjectId = "subjectId";
+
+            var claims = new List<Claim>()
+            {
+                new Claim("claim_type_1", "claims_1_value"),
+                new Claim("claim_type_2", "claims_2_value")
+            };
+
+            var eventServiceMock = new Mock<IEventService>();
+
+            // When
+            await eventServiceMock.Object.RaiseTokenRevokedEventAsync(claims, subjectId, handle, "access_token");
+
+            // Then
+            eventServiceMock.Verify(
+                x => x.RaiseAsync(
+                    It.Is<Event<TokenRevokedDetails>>(rt
+                    => rt.Details.Claims.ContainsKey("claim_type_1")
+                    && rt.Details.Claims.ContainsKey("claim_type_2")
+                    && rt.Details.Claims.Count == 2)));
+        }
+    }
+}


### PR DESCRIPTION
This change extends TokenRevokedDetails with claim property.

## Using new property
```
 public class EventHandlerService : IEventService
    {
      
        public Task RaiseAsync<T>(Event<T> @event)
        {
            if (@event.Details is TokenRevokedDetails)
            {
                var eventDetails = @event as Event<TokenRevokedDetails>;
                var sessionId = eventDetails.Details.Claims.First(x => x.Key == "session_id");
               
                // some other code
            }

            return Task.FromResult(0);
        }
    }
```