### PR TITLE
WARN instead of ERROR for bad user credentials

### DIFF
--- a/source/Core/Validation/TokenRequestValidator.cs
+++ b/source/Core/Validation/TokenRequestValidator.cs
@@ -508,7 +508,7 @@ namespace IdentityServer3.Core.Validation
                 {
                     error = "Partial signin returned from AuthenticateLocalAsync";
                 }
-                LogError("User authentication failed: " + error);
+                LogWarn("User authentication failed: " + error);
                 await RaiseFailedResourceOwnerAuthenticationEventAsync(userName, signInMessage, error);
 
                 if (authnResult != null)


### PR DESCRIPTION
Lower to WARN . Solves #3244.

As the OP in 3244, we're also monitoring the amount of ERRORS and start alerting people if above a threshold. 