### PR TITLE
Passing all claims to GetProfileDataAsync

### DIFF
--- a/source/Core/Constants.cs
+++ b/source/Core/Constants.cs
@@ -563,6 +563,8 @@ namespace IdentityServer3.Core
             public const string Id               = "id";
             public const string Secret           = "secret";
             public const string IdentityProvider = "idp";
+            /// <summary>Claim created for tenant specified in ACR value.</summary>
+            public const string Tenant           = "tenant";
             public const string Role             = "role";
             public const string ReferenceTokenId = "reference_token_id";
 

--- a/source/Core/Endpoints/Connect/UserInfoEndpointController.cs
+++ b/source/Core/Endpoints/Connect/UserInfoEndpointController.cs
@@ -95,10 +95,9 @@ namespace IdentityServer3.Core.Endpoints
             }
 
             // pass scopes/claims to profile service
-            var subject = tokenResult.Claims.FirstOrDefault(c => c.Type == Constants.ClaimTypes.Subject).Value;
             var scopes = tokenResult.Claims.Where(c => c.Type == Constants.ClaimTypes.Scope).Select(c => c.Value);
 
-            var payload = await _generator.ProcessAsync(subject, scopes, tokenResult.Client);
+            var payload = await _generator.ProcessAsync(tokenResult.Claims, scopes, tokenResult.Client);
 
             Logger.Info("End userinfo request");
             await RaiseSuccessEventAsync();

--- a/source/Core/Extensions/PrincipalExtensions.cs
+++ b/source/Core/Extensions/PrincipalExtensions.cs
@@ -196,5 +196,19 @@ namespace IdentityServer3.Core.Extensions
             if (claim == null) throw new InvalidOperationException("idp claim is missing");
             return claim.Value;
         }
+
+        /// <summary>
+        /// Gets the tenant.
+        /// </summary>
+        /// <param name="identity">The identity.</param>
+        /// <returns>Tenant if claim exists, otherwise null.</returns>
+        [DebuggerStepThrough]
+        public static string GetTenant(this IIdentity identity)
+        {
+            var id = identity as ClaimsIdentity;
+            var claim = id.FindFirst(Constants.ClaimTypes.Tenant);
+
+            return claim == null ? null : claim.Value;
+        }
     }
 }

--- a/source/Core/ResponseHandling/UserInfoResponseGenerator.cs
+++ b/source/Core/ResponseHandling/UserInfoResponseGenerator.cs
@@ -38,13 +38,13 @@ namespace IdentityServer3.Core.ResponseHandling
             _scopes = scopes;
         }
 
-        public async Task<Dictionary<string, object>> ProcessAsync(string subject, IEnumerable<string> scopes, Client client)
+        public async Task<Dictionary<string, object>> ProcessAsync(IEnumerable<Claim> claims, IEnumerable<string> scopes, Client client)
         {
             Logger.Info("Creating userinfo response");
             var profileData = new Dictionary<string, object>();
-            
+
             var requestedClaimTypes = await GetRequestedClaimTypesAsync(scopes);
-            var principal = Principal.Create("UserInfo", new Claim("sub", subject));
+            var principal = Principal.Create("UserInfo", claims.ToArray());
 
             IEnumerable<Claim> profileClaims;
             if (requestedClaimTypes.IncludeAllClaims)


### PR DESCRIPTION
Allows the usage of any claims associated with a token to be used in building ProfileData for UserInfo endpoint.

This could be necessary when identity provider and tenant are required for determining where to pull profile data from.

This will resolve Issue #3437