### PR TITLE
Make LoggedOut page wait to redirect until iframes are loaded

### DIFF
--- a/source/Core/Services/DefaultViewService/HttpAssets/app/app.js
+++ b/source/Core/Services/DefaultViewService/HttpAssets/app/app.js
@@ -56,18 +56,33 @@ window.identityServer = (function () {
                 }
             };
         });
+
+        app.directive('iframeOnload', function () {
+            var model = identityServer.getModel();
+            return {
+                link: function (scope, elem, attrs) {
+                    elem.on('load', function (event) {
+                        if (!model.autoRedirect || !model.redirectUrl) return;
+                        if ($("iframe.signout").length > 1) {
+                            event.target.remove();
+                        } else {
+                            window.location = model.redirectUrl;
+                        };
+                    });
+                }
+            };
+        });
     })();
 
     (function () {
         var model = identityServer.getModel();
         angular.module("app").constant("Model", model);
         if (model.autoRedirect && model.redirectUrl) {
-            if (model.autoRedirectDelay < 0) {
-                model.autoRedirectDelay = 0;
+            if (model.autoRedirectDelay > 0) {
+                window.setTimeout(function () {
+                    window.location = model.redirectUrl;
+                }, model.autoRedirectDelay * 1000);
             }
-            window.setTimeout(function () {
-                window.location = model.redirectUrl;
-            }, model.autoRedirectDelay * 1000);
         }
     })();
 

--- a/source/Core/Services/DefaultViewService/HttpAssets/scripts.2.5.0.js
+++ b/source/Core/Services/DefaultViewService/HttpAssets/scripts.2.5.0.js
@@ -321,18 +321,33 @@ window.identityServer = (function () {
                 }
             };
         });
+
+        app.directive('iframeOnload', function () {
+            var model = identityServer.getModel();
+            return {
+                link: function (scope, elem, attrs) {
+                    elem.on('load', function (event) {
+                        if (!model.autoRedirect || !model.redirectUrl) return;
+                        if ($("iframe.signout").length > 1) {
+                            event.target.remove();
+                        } else {
+                            window.location = model.redirectUrl;
+                        };
+                    });
+                }
+            };
+        });
     })();
 
     (function () {
         var model = identityServer.getModel();
         angular.module("app").constant("Model", model);
         if (model.autoRedirect && model.redirectUrl) {
-            if (model.autoRedirectDelay < 0) {
-                model.autoRedirectDelay = 0;
+            if (model.autoRedirectDelay > 0) {
+                window.setTimeout(function () {
+                    window.location = model.redirectUrl;
+                }, model.autoRedirectDelay * 1000);
             }
-            window.setTimeout(function () {
-                window.location = model.redirectUrl;
-            }, model.autoRedirectDelay * 1000);
         }
     })();
 

--- a/source/Core/Services/DefaultViewService/PageAssets/loggedOut.html
+++ b/source/Core/Services/DefaultViewService/PageAssets/loggedOut.html
@@ -7,5 +7,5 @@
         Click <a ng-href="{{model.redirectUrl}}">here</a> to return to the
         <span ng-bind="model.clientName"></span> application.
     </div>
-    <iframe class="signout" ng-repeat="url in model.iFrameUrls" ng-src="{{url}}"></iframe>
+    <iframe class="signout" ng-repeat="url in model.iFrameUrls" ng-src="{{url}}" iframe-onload></iframe>
 </div>


### PR DESCRIPTION
This PR addresses issue #3212, where PostSignOutAutoRedirectDelay=0 often causes the page to redirect before the single sign-out iframes have loaded.  Increasing PostSignOutAutoRedirectDelay prevents the error, but involves a trade-off between allowing for slow connections and causing unnecessarily long delays.

The fix in this PR is to detect when the iframes are loaded by adding onload event handlers using an angular directive.  When PostSignOutAutoRedirectDelay==0, it redirects when all iframes have loaded.  When PostSignOutAutoRedirectDelay > 0, it will force a redirect after the delay has passed, but will redirect sooner if the iframes are finished.  This maintains existing functionality by allowing a maximum delay to be specified, while otherwise providing the fastest possible sign-out flow.

A similar approach is used in IdentityServer4 by redirecting on window-load.  Since we need to use IdentityServer3 for a while longer, I was looking for a way to accomplish the same thing using its angular-generated signout iframes.