### PR TITLE
Minor fixes

### DIFF
--- a/source/Core/Configuration/Hosting/AntiForgeryToken.cs
+++ b/source/Core/Configuration/Hosting/AntiForgeryToken.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 namespace IdentityServer3.Core.Configuration.Hosting
 {
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public class AntiForgeryToken
+    internal class AntiForgeryToken
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
 

--- a/source/Core/Configuration/Hosting/ErrorPageFilterAttribute.cs
+++ b/source/Core/Configuration/Hosting/ErrorPageFilterAttribute.cs
@@ -27,8 +27,6 @@ namespace IdentityServer3.Core.Configuration.Hosting
 {
     internal class ErrorPageFilterAttribute : ExceptionFilterAttribute
     {
-        private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();
-        
         public override async System.Threading.Tasks.Task OnExceptionAsync(HttpActionExecutedContext actionExecutedContext, System.Threading.CancellationToken cancellationToken)
         {
             var env = actionExecutedContext.ActionContext.Request.GetOwinEnvironment();


### PR DESCRIPTION
PR includes two points:
* Remove unused logger because all exceptions are logged by IExceptionLogger attached into WebApi middleware.
* Fix `AntiForgeryToken` access to internal - this class has only internal constructors.