### PR TITLE
Add maximum version for System.IdentityModel.Tokens.Jwt < 5.0 due to …

### DIFF
--- a/source/IdentityServer3.nuspec
+++ b/source/IdentityServer3.nuspec
@@ -19,6 +19,7 @@
     <tags>IdentityServer OpenID Connect OpenIDConnect OAuth2 OWIN ASP.NET Katana WebApi SSO Federation Claims Identity</tags>
     <dependencies>
       <dependency id="Owin" version="1.0"/>
+      <dependency id="System.IdentityModel.Tokens.Jwt" version="(,5.0)" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
Add max version dependency on System.IdentityModel.Tokens.Jwt, to warn developers of incompatibilty. Fixes #3017 