### PR TITLE
Configurable Cache Control for Discovery Endpoints

### DIFF
--- a/source/Core/Configuration/DiscoveryOptions.cs
+++ b/source/Core/Configuration/DiscoveryOptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace IdentityServer3.Core.Configuration
 {
@@ -58,6 +59,14 @@ namespace IdentityServer3.Core.Configuration
         public bool ShowTokenEndpointAuthenticationMethods { get; set; }
 
         /// <summary>
+        /// Sets the maxage value of the cache control header. This gives clients a hint how often they should refresh their cached copy of the discovery document (defaults to one hour).
+        /// </summary>
+        /// <value>
+        /// The cache interval.
+        /// </value>
+        public TimeSpan ClientCacheInterval { get; set; }
+
+        /// <summary>
         /// Adds custom entries to the discovery document
         /// </summary>
         public Dictionary<string, object> CustomEntries { get; set; }
@@ -77,6 +86,7 @@ namespace IdentityServer3.Core.Configuration
             ShowGrantTypes = true;
             ShowCustomGrantTypes = true;
             ShowTokenEndpointAuthenticationMethods = true;
+            ClientCacheInterval = TimeSpan.FromHours(1);
             CustomEntries = new Dictionary<string, object>();
         }
     }

--- a/source/Core/Configuration/Hosting/DiscoveryCacheControlAttribute.cs
+++ b/source/Core/Configuration/Hosting/DiscoveryCacheControlAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Web.Http.Filters;
+using IdentityServer3.Core.Extensions;
+
+namespace IdentityServer3.Core.Configuration.Hosting
+{
+    internal class DiscoveryCacheControlAttribute : ActionFilterAttribute
+    {
+        public override void OnActionExecuted(HttpActionExecutedContext actionExecutedContext)
+        {
+            base.OnActionExecuted(actionExecutedContext);
+            
+            var ctx = actionExecutedContext.Request.GetOwinContext();
+            var options = ctx.ResolveDependency<IdentityServerOptions>();
+            SetCache(actionExecutedContext.Response, options.DiscoveryOptions.ClientCacheInterval);
+        }
+
+        public static void SetCache(HttpResponseMessage response, TimeSpan maxAge)
+        {
+            response.Headers.CacheControl = new CacheControlHeaderValue { MaxAge = maxAge };
+        }
+    }
+}

--- a/source/Core/Core.csproj
+++ b/source/Core/Core.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Configuration\DiscoveryOptions.cs" />
     <Compile Include="Configuration\EventsOptions.cs" />
     <Compile Include="Configuration\Hosting\ClientListCookie.cs" />
+    <Compile Include="Configuration\Hosting\DiscoveryCacheControlAttribute.cs" />
     <Compile Include="Configuration\InputLengthRestrictions.cs" />
     <Compile Include="Configuration\IAuthenticationSessionStoreProvider.cs" />
     <Compile Include="Configuration\X509CertificateDataProtector.cs" />

--- a/source/Core/Endpoints/Connect/DiscoveryEndpointController.cs
+++ b/source/Core/Endpoints/Connect/DiscoveryEndpointController.cs
@@ -31,12 +31,14 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using System.Web.Http;
+using IdentityServer3.Core.Configuration.Hosting;
 
 namespace IdentityServer3.Core.Endpoints
 {
     /// <summary>
     /// OpenID Connect discovery document endpoint
     /// </summary>
+    [DiscoveryCacheControl]
     internal class DiscoveryEndpointController : ApiController
     {
         private readonly static ILog Logger = LogProvider.GetCurrentClassLogger();


### PR DESCRIPTION
Adds feature requested for IdentityServer4 in IdentityServer/IdentityServer4#810 but this time for IdentityServer3
> It would be nice if there was a supported way to define cache headers for the discovery endpoint. Right now, our resource servers assume that the jwk immediately expires if there is no cache header set.

Add DiscoveryOptions.ClientCacheInterval to set the maxage cache control header on the discovery endpoints. Defaults to one hour.

This gives clients a hint how often they should refresh their cached copy of the discovery document.

Feature implemented in a similar manner to IdentityServer4 IdentityServer/IdentityServer4@58e6c3a