### PR TITLE
Adding Prompt to SignInMessage so it can be propagated

### DIFF
--- a/source/Core/Models/SignInMessage.cs
+++ b/source/Core/Models/SignInMessage.cs
@@ -93,6 +93,14 @@ namespace IdentityServer3.Core.Models
         public IEnumerable<string> AcrValues { get; set; }
 
         /// <summary>
+        /// The prompt value passed from the authorization request.
+        /// </summary>
+        /// <value>
+        /// The prompt value
+        /// </value>
+        public string Prompt { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="SignInMessage"/> class.
         /// </summary>
         public SignInMessage()

--- a/source/Core/ResponseHandling/AuthorizeInteractionResponseGenerator.cs
+++ b/source/Core/ResponseHandling/AuthorizeInteractionResponseGenerator.cs
@@ -100,6 +100,12 @@ namespace IdentityServer3.Core.ResponseHandling
                 _signIn.AcrValues = acrValues;
             }
 
+            // pass through the prompt mode
+            if (request.PromptMode.IsPresent())
+            {
+                _signIn.Prompt = request.PromptMode;
+            }
+
             if (request.PromptMode == Constants.PromptModes.Login)
             {
                 // remove prompt so when we redirect back in from login page


### PR DESCRIPTION
I have a need to be able to propagate the prompt parameter from a client to an upstream IDP. This wasn't possible as it wasn't included in the sign in message.

I've added a new property to the sign in message and set the prompt value in the appropriate place.